### PR TITLE
chore(triage): actions use v prefixed versions

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -11,7 +11,7 @@ jobs:
     permissions:
       issues: write
     steps:
-      - uses: actions/add-to-project@0.4.0
+      - uses: actions/add-to-project@v0.4.0
         with:
           project-url: https://github.com/orgs/cdk8s-team/projects/12
           github-token: ${{ secrets.PROJEN_GITHUB_TOKEN }}

--- a/src/components/triage/triage.ts
+++ b/src/components/triage/triage.ts
@@ -26,7 +26,7 @@ export class Triage extends Component {
       permissions: { issues: JobPermission.WRITE },
       runsOn: ['ubuntu-latest'],
       steps: [{
-        uses: 'actions/add-to-project@0.4.0',
+        uses: 'actions/add-to-project@v0.4.0',
         with: {
           'project-url': projectUrl,
           'github-token': '${{ secrets.PROJEN_GITHUB_TOKEN }}',

--- a/test/projects/__snapshots__/jsii.test.ts.snap
+++ b/test/projects/__snapshots__/jsii.test.ts.snap
@@ -520,7 +520,7 @@ jobs:
     permissions:
       issues: write
     steps:
-      - uses: actions/add-to-project@0.4.0
+      - uses: actions/add-to-project@v0.4.0
         with:
           project-url: https://github.com/orgs/cdk8s-team/projects/12
           github-token: \${{ secrets.PROJEN_GITHUB_TOKEN }}
@@ -2159,7 +2159,7 @@ jobs:
     permissions:
       issues: write
     steps:
-      - uses: actions/add-to-project@0.4.0
+      - uses: actions/add-to-project@v0.4.0
         with:
           project-url: https://github.com/orgs/cdk8s-team/projects/12
           github-token: \${{ secrets.PROJEN_GITHUB_TOKEN }}
@@ -3758,7 +3758,7 @@ jobs:
     permissions:
       issues: write
     steps:
-      - uses: actions/add-to-project@0.4.0
+      - uses: actions/add-to-project@v0.4.0
         with:
           project-url: https://github.com/orgs/cdk8s-team/projects/12
           github-token: \${{ secrets.PROJEN_GITHUB_TOKEN }}
@@ -5397,7 +5397,7 @@ jobs:
     permissions:
       issues: write
     steps:
-      - uses: actions/add-to-project@0.4.0
+      - uses: actions/add-to-project@v0.4.0
         with:
           project-url: https://github.com/orgs/cdk8s-team/projects/12
           github-token: \${{ secrets.PROJEN_GITHUB_TOKEN }}
@@ -6996,7 +6996,7 @@ jobs:
     permissions:
       issues: write
     steps:
-      - uses: actions/add-to-project@0.4.0
+      - uses: actions/add-to-project@v0.4.0
         with:
           project-url: https://github.com/orgs/cdk8s-team/projects/12
           github-token: \${{ secrets.PROJEN_GITHUB_TOKEN }}
@@ -8635,7 +8635,7 @@ jobs:
     permissions:
       issues: write
     steps:
-      - uses: actions/add-to-project@0.4.0
+      - uses: actions/add-to-project@v0.4.0
         with:
           project-url: https://github.com/orgs/cdk8s-team/projects/12
           github-token: \${{ secrets.PROJEN_GITHUB_TOKEN }}
@@ -10636,7 +10636,7 @@ jobs:
     permissions:
       issues: write
     steps:
-      - uses: actions/add-to-project@0.4.0
+      - uses: actions/add-to-project@v0.4.0
         with:
           project-url: https://github.com/orgs/cdk8s-team/projects/12
           github-token: \${{ secrets.PROJEN_GITHUB_TOKEN }}
@@ -12727,7 +12727,7 @@ jobs:
     permissions:
       issues: write
     steps:
-      - uses: actions/add-to-project@0.4.0
+      - uses: actions/add-to-project@v0.4.0
         with:
           project-url: https://github.com/orgs/cdk8s-team/projects/12
           github-token: \${{ secrets.PROJEN_GITHUB_TOKEN }}
@@ -14818,7 +14818,7 @@ jobs:
     permissions:
       issues: write
     steps:
-      - uses: actions/add-to-project@0.4.0
+      - uses: actions/add-to-project@v0.4.0
         with:
           project-url: https://github.com/orgs/cdk8s-team/projects/12
           github-token: \${{ secrets.PROJEN_GITHUB_TOKEN }}
@@ -16909,7 +16909,7 @@ jobs:
     permissions:
       issues: write
     steps:
-      - uses: actions/add-to-project@0.4.0
+      - uses: actions/add-to-project@v0.4.0
         with:
           project-url: https://github.com/orgs/cdk8s-team/projects/12
           github-token: \${{ secrets.PROJEN_GITHUB_TOKEN }}
@@ -19000,7 +19000,7 @@ jobs:
     permissions:
       issues: write
     steps:
-      - uses: actions/add-to-project@0.4.0
+      - uses: actions/add-to-project@v0.4.0
         with:
           project-url: https://github.com/orgs/cdk8s-team/projects/12
           github-token: \${{ secrets.PROJEN_GITHUB_TOKEN }}

--- a/test/projects/__snapshots__/node.test.ts.snap
+++ b/test/projects/__snapshots__/node.test.ts.snap
@@ -286,7 +286,7 @@ jobs:
     permissions:
       issues: write
     steps:
-      - uses: actions/add-to-project@0.4.0
+      - uses: actions/add-to-project@v0.4.0
         with:
           project-url: https://github.com/orgs/cdk8s-team/projects/12
           github-token: \${{ secrets.PROJEN_GITHUB_TOKEN }}
@@ -1336,7 +1336,7 @@ jobs:
     permissions:
       issues: write
     steps:
-      - uses: actions/add-to-project@0.4.0
+      - uses: actions/add-to-project@v0.4.0
         with:
           project-url: https://github.com/orgs/cdk8s-team/projects/12
           github-token: \${{ secrets.PROJEN_GITHUB_TOKEN }}
@@ -2386,7 +2386,7 @@ jobs:
     permissions:
       issues: write
     steps:
-      - uses: actions/add-to-project@0.4.0
+      - uses: actions/add-to-project@v0.4.0
         with:
           project-url: https://github.com/orgs/cdk8s-team/projects/12
           github-token: \${{ secrets.PROJEN_GITHUB_TOKEN }}
@@ -3510,7 +3510,7 @@ jobs:
     permissions:
       issues: write
     steps:
-      - uses: actions/add-to-project@0.4.0
+      - uses: actions/add-to-project@v0.4.0
         with:
           project-url: https://github.com/orgs/cdk8s-team/projects/12
           github-token: \${{ secrets.PROJEN_GITHUB_TOKEN }}
@@ -4709,7 +4709,7 @@ jobs:
     permissions:
       issues: write
     steps:
-      - uses: actions/add-to-project@0.4.0
+      - uses: actions/add-to-project@v0.4.0
         with:
           project-url: https://github.com/orgs/cdk8s-team/projects/12
           github-token: \${{ secrets.PROJEN_GITHUB_TOKEN }}
@@ -5908,7 +5908,7 @@ jobs:
     permissions:
       issues: write
     steps:
-      - uses: actions/add-to-project@0.4.0
+      - uses: actions/add-to-project@v0.4.0
         with:
           project-url: https://github.com/orgs/cdk8s-team/projects/12
           github-token: \${{ secrets.PROJEN_GITHUB_TOKEN }}
@@ -7107,7 +7107,7 @@ jobs:
     permissions:
       issues: write
     steps:
-      - uses: actions/add-to-project@0.4.0
+      - uses: actions/add-to-project@v0.4.0
         with:
           project-url: https://github.com/orgs/cdk8s-team/projects/12
           github-token: \${{ secrets.PROJEN_GITHUB_TOKEN }}
@@ -8306,7 +8306,7 @@ jobs:
     permissions:
       issues: write
     steps:
-      - uses: actions/add-to-project@0.4.0
+      - uses: actions/add-to-project@v0.4.0
         with:
           project-url: https://github.com/orgs/cdk8s-team/projects/12
           github-token: \${{ secrets.PROJEN_GITHUB_TOKEN }}

--- a/test/projects/__snapshots__/typescript.test.ts.snap
+++ b/test/projects/__snapshots__/typescript.test.ts.snap
@@ -520,7 +520,7 @@ jobs:
     permissions:
       issues: write
     steps:
-      - uses: actions/add-to-project@0.4.0
+      - uses: actions/add-to-project@v0.4.0
         with:
           project-url: https://github.com/orgs/cdk8s-team/projects/12
           github-token: \${{ secrets.PROJEN_GITHUB_TOKEN }}
@@ -1994,7 +1994,7 @@ jobs:
     permissions:
       issues: write
     steps:
-      - uses: actions/add-to-project@0.4.0
+      - uses: actions/add-to-project@v0.4.0
         with:
           project-url: https://github.com/orgs/cdk8s-team/projects/12
           github-token: \${{ secrets.PROJEN_GITHUB_TOKEN }}
@@ -3468,7 +3468,7 @@ jobs:
     permissions:
       issues: write
     steps:
-      - uses: actions/add-to-project@0.4.0
+      - uses: actions/add-to-project@v0.4.0
         with:
           project-url: https://github.com/orgs/cdk8s-team/projects/12
           github-token: \${{ secrets.PROJEN_GITHUB_TOKEN }}
@@ -5016,7 +5016,7 @@ jobs:
     permissions:
       issues: write
     steps:
-      - uses: actions/add-to-project@0.4.0
+      - uses: actions/add-to-project@v0.4.0
         with:
           project-url: https://github.com/orgs/cdk8s-team/projects/12
           github-token: \${{ secrets.PROJEN_GITHUB_TOKEN }}
@@ -6639,7 +6639,7 @@ jobs:
     permissions:
       issues: write
     steps:
-      - uses: actions/add-to-project@0.4.0
+      - uses: actions/add-to-project@v0.4.0
         with:
           project-url: https://github.com/orgs/cdk8s-team/projects/12
           github-token: \${{ secrets.PROJEN_GITHUB_TOKEN }}
@@ -8262,7 +8262,7 @@ jobs:
     permissions:
       issues: write
     steps:
-      - uses: actions/add-to-project@0.4.0
+      - uses: actions/add-to-project@v0.4.0
         with:
           project-url: https://github.com/orgs/cdk8s-team/projects/12
           github-token: \${{ secrets.PROJEN_GITHUB_TOKEN }}
@@ -9885,7 +9885,7 @@ jobs:
     permissions:
       issues: write
     steps:
-      - uses: actions/add-to-project@0.4.0
+      - uses: actions/add-to-project@v0.4.0
         with:
           project-url: https://github.com/orgs/cdk8s-team/projects/12
           github-token: \${{ secrets.PROJEN_GITHUB_TOKEN }}
@@ -11508,7 +11508,7 @@ jobs:
     permissions:
       issues: write
     steps:
-      - uses: actions/add-to-project@0.4.0
+      - uses: actions/add-to-project@v0.4.0
         with:
           project-url: https://github.com/orgs/cdk8s-team/projects/12
           github-token: \${{ secrets.PROJEN_GITHUB_TOKEN }}


### PR DESCRIPTION
Fixes action failing, e.g. https://github.com/cdk8s-team/cdk8s-plus/actions/runs/4249004636