### PR TITLE
fix(triage): repository names are malformed

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -14,7 +14,7 @@ jobs:
     permissions:
       issues: write
       pull-requests: write
-    if: github.repository == cdk8s-team/cdk8s-projen-common
+    if: github.repository == 'cdk8s-team/cdk8s-projen-common'
     steps:
       - uses: actions/add-to-project@v0.4.0
         with:

--- a/src/components/triage/triage.ts
+++ b/src/components/triage/triage.ts
@@ -41,7 +41,7 @@ export class Triage extends Component {
       permissions: { issues: JobPermission.WRITE, pullRequests: JobPermission.WRITE },
       // dont run this action in forks as it contains a hard link to our project board.
       // see https://docs.github.com/en/actions/using-jobs/using-conditions-to-control-job-execution#example-only-run-job-for-specific-repository
-      if: `github.repository == cdk8s-team/${options.repoName}`,
+      if: `github.repository == \'cdk8s-team/${options.repoName}\'`,
       runsOn: ['ubuntu-latest'],
       steps: [{
         uses: 'actions/add-to-project@v0.4.0',

--- a/test/projects/__snapshots__/jsii.test.ts.snap
+++ b/test/projects/__snapshots__/jsii.test.ts.snap
@@ -970,7 +970,7 @@ jobs:
     permissions:
       issues: write
       pull-requests: write
-    if: github.repository == cdk8s-team/root
+    if: github.repository == 'cdk8s-team/root'
     steps:
       - uses: actions/add-to-project@v0.4.0
         with:
@@ -2714,7 +2714,7 @@ jobs:
     permissions:
       issues: write
       pull-requests: write
-    if: github.repository == cdk8s-team/custom-repo-name
+    if: github.repository == 'cdk8s-team/custom-repo-name'
     steps:
       - uses: actions/add-to-project@v0.4.0
         with:
@@ -4375,7 +4375,7 @@ jobs:
     permissions:
       issues: write
       pull-requests: write
-    if: github.repository == cdk8s-team/custom-repo-name
+    if: github.repository == 'cdk8s-team/custom-repo-name'
     steps:
       - uses: actions/add-to-project@v0.4.0
         with:
@@ -5996,7 +5996,7 @@ jobs:
     permissions:
       issues: write
       pull-requests: write
-    if: github.repository == cdk8s-team/custom-repo-name
+    if: github.repository == 'cdk8s-team/custom-repo-name'
     steps:
       - uses: actions/add-to-project@v0.4.0
         with:
@@ -7657,7 +7657,7 @@ jobs:
     permissions:
       issues: write
       pull-requests: write
-    if: github.repository == cdk8s-team/custom-repo-name
+    if: github.repository == 'cdk8s-team/custom-repo-name'
     steps:
       - uses: actions/add-to-project@v0.4.0
         with:
@@ -9278,7 +9278,7 @@ jobs:
     permissions:
       issues: write
       pull-requests: write
-    if: github.repository == cdk8s-team/custom-repo-name
+    if: github.repository == 'cdk8s-team/custom-repo-name'
     steps:
       - uses: actions/add-to-project@v0.4.0
         with:
@@ -10939,7 +10939,7 @@ jobs:
     permissions:
       issues: write
       pull-requests: write
-    if: github.repository == cdk8s-team/custom-repo-name
+    if: github.repository == 'cdk8s-team/custom-repo-name'
     steps:
       - uses: actions/add-to-project@v0.4.0
         with:
@@ -12962,7 +12962,7 @@ jobs:
     permissions:
       issues: write
       pull-requests: write
-    if: github.repository == cdk8s-team/cdk8s-sample
+    if: github.repository == 'cdk8s-team/cdk8s-sample'
     steps:
       - uses: actions/add-to-project@v0.4.0
         with:
@@ -15075,7 +15075,7 @@ jobs:
     permissions:
       issues: write
       pull-requests: write
-    if: github.repository == cdk8s-team/root
+    if: github.repository == 'cdk8s-team/root'
     steps:
       - uses: actions/add-to-project@v0.4.0
         with:
@@ -17188,7 +17188,7 @@ jobs:
     permissions:
       issues: write
       pull-requests: write
-    if: github.repository == cdk8s-team/cdk8s-sample
+    if: github.repository == 'cdk8s-team/cdk8s-sample'
     steps:
       - uses: actions/add-to-project@v0.4.0
         with:
@@ -19301,7 +19301,7 @@ jobs:
     permissions:
       issues: write
       pull-requests: write
-    if: github.repository == cdk8s-team/cdk8s
+    if: github.repository == 'cdk8s-team/cdk8s'
     steps:
       - uses: actions/add-to-project@v0.4.0
         with:
@@ -21414,7 +21414,7 @@ jobs:
     permissions:
       issues: write
       pull-requests: write
-    if: github.repository == cdk8s-team/root
+    if: github.repository == 'cdk8s-team/root'
     steps:
       - uses: actions/add-to-project@v0.4.0
         with:

--- a/test/projects/__snapshots__/node.test.ts.snap
+++ b/test/projects/__snapshots__/node.test.ts.snap
@@ -408,7 +408,7 @@ jobs:
     permissions:
       issues: write
       pull-requests: write
-    if: github.repository == cdk8s-team/root
+    if: github.repository == 'cdk8s-team/root'
     steps:
       - uses: actions/add-to-project@v0.4.0
         with:
@@ -1588,7 +1588,7 @@ jobs:
     permissions:
       issues: write
       pull-requests: write
-    if: github.repository == cdk8s-team/custom-repo-name
+    if: github.repository == 'cdk8s-team/custom-repo-name'
     steps:
       - uses: actions/add-to-project@v0.4.0
         with:
@@ -2660,7 +2660,7 @@ jobs:
     permissions:
       issues: write
       pull-requests: write
-    if: github.repository == cdk8s-team/custom-repo-name
+    if: github.repository == 'cdk8s-team/custom-repo-name'
     steps:
       - uses: actions/add-to-project@v0.4.0
         with:
@@ -3732,7 +3732,7 @@ jobs:
     permissions:
       issues: write
       pull-requests: write
-    if: github.repository == cdk8s-team/custom-repo-name
+    if: github.repository == 'cdk8s-team/custom-repo-name'
     steps:
       - uses: actions/add-to-project@v0.4.0
         with:
@@ -4878,7 +4878,7 @@ jobs:
     permissions:
       issues: write
       pull-requests: write
-    if: github.repository == cdk8s-team/cdk8s-sample
+    if: github.repository == 'cdk8s-team/cdk8s-sample'
     steps:
       - uses: actions/add-to-project@v0.4.0
         with:
@@ -6099,7 +6099,7 @@ jobs:
     permissions:
       issues: write
       pull-requests: write
-    if: github.repository == cdk8s-team/root
+    if: github.repository == 'cdk8s-team/root'
     steps:
       - uses: actions/add-to-project@v0.4.0
         with:
@@ -7320,7 +7320,7 @@ jobs:
     permissions:
       issues: write
       pull-requests: write
-    if: github.repository == cdk8s-team/cdk8s-sample
+    if: github.repository == 'cdk8s-team/cdk8s-sample'
     steps:
       - uses: actions/add-to-project@v0.4.0
         with:
@@ -8541,7 +8541,7 @@ jobs:
     permissions:
       issues: write
       pull-requests: write
-    if: github.repository == cdk8s-team/cdk8s
+    if: github.repository == 'cdk8s-team/cdk8s'
     steps:
       - uses: actions/add-to-project@v0.4.0
         with:
@@ -9762,7 +9762,7 @@ jobs:
     permissions:
       issues: write
       pull-requests: write
-    if: github.repository == cdk8s-team/root
+    if: github.repository == 'cdk8s-team/root'
     steps:
       - uses: actions/add-to-project@v0.4.0
         with:

--- a/test/projects/__snapshots__/typescript.test.ts.snap
+++ b/test/projects/__snapshots__/typescript.test.ts.snap
@@ -642,7 +642,7 @@ jobs:
     permissions:
       issues: write
       pull-requests: write
-    if: github.repository == cdk8s-team/root
+    if: github.repository == 'cdk8s-team/root'
     steps:
       - uses: actions/add-to-project@v0.4.0
         with:
@@ -2246,7 +2246,7 @@ jobs:
     permissions:
       issues: write
       pull-requests: write
-    if: github.repository == cdk8s-team/custom-repo-name
+    if: github.repository == 'cdk8s-team/custom-repo-name'
     steps:
       - uses: actions/add-to-project@v0.4.0
         with:
@@ -3742,7 +3742,7 @@ jobs:
     permissions:
       issues: write
       pull-requests: write
-    if: github.repository == cdk8s-team/custom-repo-name
+    if: github.repository == 'cdk8s-team/custom-repo-name'
     steps:
       - uses: actions/add-to-project@v0.4.0
         with:
@@ -5238,7 +5238,7 @@ jobs:
     permissions:
       issues: write
       pull-requests: write
-    if: github.repository == cdk8s-team/custom-repo-name
+    if: github.repository == 'cdk8s-team/custom-repo-name'
     steps:
       - uses: actions/add-to-project@v0.4.0
         with:
@@ -6808,7 +6808,7 @@ jobs:
     permissions:
       issues: write
       pull-requests: write
-    if: github.repository == cdk8s-team/root
+    if: github.repository == 'cdk8s-team/root'
     steps:
       - uses: actions/add-to-project@v0.4.0
         with:
@@ -8453,7 +8453,7 @@ jobs:
     permissions:
       issues: write
       pull-requests: write
-    if: github.repository == cdk8s-team/cdk8s-sample
+    if: github.repository == 'cdk8s-team/cdk8s-sample'
     steps:
       - uses: actions/add-to-project@v0.4.0
         with:
@@ -10098,7 +10098,7 @@ jobs:
     permissions:
       issues: write
       pull-requests: write
-    if: github.repository == cdk8s-team/cdk8s-sample
+    if: github.repository == 'cdk8s-team/cdk8s-sample'
     steps:
       - uses: actions/add-to-project@v0.4.0
         with:
@@ -11743,7 +11743,7 @@ jobs:
     permissions:
       issues: write
       pull-requests: write
-    if: github.repository == cdk8s-team/cdk8s
+    if: github.repository == 'cdk8s-team/cdk8s'
     steps:
       - uses: actions/add-to-project@v0.4.0
         with:
@@ -13388,7 +13388,7 @@ jobs:
     permissions:
       issues: write
       pull-requests: write
-    if: github.repository == cdk8s-team/root
+    if: github.repository == 'cdk8s-team/root'
     steps:
       - uses: actions/add-to-project@v0.4.0
         with:


### PR DESCRIPTION
Our current workflows are [failing](https://github.com/cdk8s-team/cdk8s-dependabot-security-alerts/actions/runs/4430195739) with:

```console
The workflow is not valid. .github/workflows/triage.yml (Line: 17, Col: 9): Unexpected symbol: 'cdk8s-team/cdk8s-dependabot-security-alerts'. Located at position 22 within expression: github.repository == cdk8s-team/cdk8s-dependabot-security-alerts
```