### PR TITLE
fix: workflow builds are broken due to node version mismatch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - name: Install dependencies
         run: yarn install --check-files
       - name: build
@@ -89,7 +89,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: release
@@ -55,7 +55,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -84,7 +84,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/upgrade-main.yml
+++ b/.github/workflows/upgrade-main.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies

--- a/src/projects/node.ts
+++ b/src/projects/node.ts
@@ -68,7 +68,7 @@ Pick<javascript.NodeProjectOptions, defaultOptionsKeysType> {
     // if release is enabled, default to releasing to npm as well
     releaseToNpm: options.release,
     minNodeVersion: '14.17.0',
-    workflowNodeVersion: '16.13.0',
+    workflowNodeVersion: '16.20.0',
   };
 }
 

--- a/test/projects/__snapshots__/jsii.test.ts.snap
+++ b/test/projects/__snapshots__/jsii.test.ts.snap
@@ -474,7 +474,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - name: Install dependencies
         run: yarn install --check-files
       - name: build
@@ -541,7 +541,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -570,7 +570,7 @@ jobs:
           java-version: 11.x
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -595,7 +595,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - uses: actions/setup-python@v4
         with:
           python-version: 3.x
@@ -623,7 +623,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - uses: actions/setup-dotnet@v3
         with:
           dotnet-version: 3.x
@@ -651,7 +651,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - uses: actions/setup-go@v3
         with:
           go-version: ^1.16.0
@@ -730,7 +730,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: release
@@ -758,7 +758,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -787,7 +787,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -824,7 +824,7 @@ jobs:
           java-version: 11.x
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -859,7 +859,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - uses: actions/setup-python@v4
         with:
           python-version: 3.x
@@ -894,7 +894,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - uses: actions/setup-dotnet@v3
         with:
           dotnet-version: 3.x
@@ -928,7 +928,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - uses: actions/setup-go@v3
         with:
           go-version: ^1.16.0
@@ -1058,7 +1058,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -2683,7 +2683,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - name: Install dependencies
         run: yarn install --check-files
       - name: build
@@ -2864,7 +2864,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -4287,7 +4287,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - name: Install dependencies
         run: yarn install --check-files
       - name: build
@@ -4358,7 +4358,7 @@ jobs:
           java-version: 11.x
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -4383,7 +4383,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - uses: actions/setup-python@v4
         with:
           python-version: 3.x
@@ -4411,7 +4411,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - uses: actions/setup-dotnet@v3
         with:
           dotnet-version: 3.x
@@ -4439,7 +4439,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - uses: actions/setup-go@v3
         with:
           go-version: ^1.16.0
@@ -4589,7 +4589,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -6093,7 +6093,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - name: Install dependencies
         run: yarn install --check-files
       - name: build
@@ -6274,7 +6274,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -7697,7 +7697,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - name: Install dependencies
         run: yarn install --check-files
       - name: build
@@ -7768,7 +7768,7 @@ jobs:
           java-version: 11.x
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -7793,7 +7793,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - uses: actions/setup-python@v4
         with:
           python-version: 3.x
@@ -7821,7 +7821,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - uses: actions/setup-dotnet@v3
         with:
           dotnet-version: 3.x
@@ -7849,7 +7849,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - uses: actions/setup-go@v3
         with:
           go-version: ^1.16.0
@@ -7999,7 +7999,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -9503,7 +9503,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - name: Install dependencies
         run: yarn install --check-files
       - name: build
@@ -9684,7 +9684,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -11107,7 +11107,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - name: Install dependencies
         run: yarn install --check-files
       - name: build
@@ -11178,7 +11178,7 @@ jobs:
           java-version: 11.x
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -11203,7 +11203,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - uses: actions/setup-python@v4
         with:
           python-version: 3.x
@@ -11231,7 +11231,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - uses: actions/setup-dotnet@v3
         with:
           dotnet-version: 3.x
@@ -11259,7 +11259,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - uses: actions/setup-go@v3
         with:
           go-version: ^1.16.0
@@ -11409,7 +11409,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -12914,7 +12914,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - name: Install dependencies
         run: yarn install --check-files
       - name: build
@@ -12981,7 +12981,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -13010,7 +13010,7 @@ jobs:
           java-version: 11.x
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -13035,7 +13035,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - uses: actions/setup-python@v4
         with:
           python-version: 3.x
@@ -13063,7 +13063,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - uses: actions/setup-dotnet@v3
         with:
           dotnet-version: 3.x
@@ -13091,7 +13091,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - uses: actions/setup-go@v3
         with:
           go-version: ^1.16.0
@@ -13170,7 +13170,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: release
@@ -13198,7 +13198,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -13227,7 +13227,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -13264,7 +13264,7 @@ jobs:
           java-version: 11.x
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -13299,7 +13299,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - uses: actions/setup-python@v4
         with:
           python-version: 3.x
@@ -13334,7 +13334,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - uses: actions/setup-dotnet@v3
         with:
           dotnet-version: 3.x
@@ -13368,7 +13368,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - uses: actions/setup-go@v3
         with:
           go-version: ^1.16.0
@@ -13498,7 +13498,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -15091,7 +15091,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - name: Install dependencies
         run: yarn install --check-files
       - name: build
@@ -15158,7 +15158,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -15187,7 +15187,7 @@ jobs:
           java-version: 11.x
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -15212,7 +15212,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - uses: actions/setup-python@v4
         with:
           python-version: 3.x
@@ -15240,7 +15240,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - uses: actions/setup-dotnet@v3
         with:
           dotnet-version: 3.x
@@ -15268,7 +15268,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - uses: actions/setup-go@v3
         with:
           go-version: ^1.16.0
@@ -15347,7 +15347,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: release
@@ -15375,7 +15375,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -15404,7 +15404,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -15441,7 +15441,7 @@ jobs:
           java-version: 11.x
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -15476,7 +15476,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - uses: actions/setup-python@v4
         with:
           python-version: 3.x
@@ -15511,7 +15511,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - uses: actions/setup-dotnet@v3
         with:
           dotnet-version: 3.x
@@ -15545,7 +15545,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - uses: actions/setup-go@v3
         with:
           go-version: ^1.16.0
@@ -15675,7 +15675,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -17268,7 +17268,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - name: Install dependencies
         run: yarn install --check-files
       - name: build
@@ -17335,7 +17335,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -17364,7 +17364,7 @@ jobs:
           java-version: 11.x
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -17389,7 +17389,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - uses: actions/setup-python@v4
         with:
           python-version: 3.x
@@ -17417,7 +17417,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - uses: actions/setup-dotnet@v3
         with:
           dotnet-version: 3.x
@@ -17445,7 +17445,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - uses: actions/setup-go@v3
         with:
           go-version: ^1.16.0
@@ -17524,7 +17524,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: release
@@ -17552,7 +17552,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -17581,7 +17581,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -17618,7 +17618,7 @@ jobs:
           java-version: 11.x
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -17653,7 +17653,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - uses: actions/setup-python@v4
         with:
           python-version: 3.x
@@ -17688,7 +17688,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - uses: actions/setup-dotnet@v3
         with:
           dotnet-version: 3.x
@@ -17722,7 +17722,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - uses: actions/setup-go@v3
         with:
           go-version: ^1.16.0
@@ -17852,7 +17852,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -19445,7 +19445,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - name: Install dependencies
         run: yarn install --check-files
       - name: build
@@ -19512,7 +19512,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -19541,7 +19541,7 @@ jobs:
           java-version: 11.x
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -19566,7 +19566,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - uses: actions/setup-python@v4
         with:
           python-version: 3.x
@@ -19594,7 +19594,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - uses: actions/setup-dotnet@v3
         with:
           dotnet-version: 3.x
@@ -19622,7 +19622,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - uses: actions/setup-go@v3
         with:
           go-version: ^1.16.0
@@ -19701,7 +19701,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: release
@@ -19729,7 +19729,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -19758,7 +19758,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -19795,7 +19795,7 @@ jobs:
           java-version: 11.x
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -19830,7 +19830,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - uses: actions/setup-python@v4
         with:
           python-version: 3.x
@@ -19865,7 +19865,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - uses: actions/setup-dotnet@v3
         with:
           dotnet-version: 3.x
@@ -19899,7 +19899,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - uses: actions/setup-go@v3
         with:
           go-version: ^1.16.0
@@ -20029,7 +20029,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -21622,7 +21622,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - name: Install dependencies
         run: yarn install --check-files
       - name: build
@@ -21689,7 +21689,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -21718,7 +21718,7 @@ jobs:
           java-version: 11.x
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -21743,7 +21743,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - uses: actions/setup-python@v4
         with:
           python-version: 3.x
@@ -21771,7 +21771,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - uses: actions/setup-dotnet@v3
         with:
           dotnet-version: 3.x
@@ -21799,7 +21799,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - uses: actions/setup-go@v3
         with:
           go-version: ^1.16.0
@@ -21878,7 +21878,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: release
@@ -21906,7 +21906,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -21935,7 +21935,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -21972,7 +21972,7 @@ jobs:
           java-version: 11.x
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -22007,7 +22007,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - uses: actions/setup-python@v4
         with:
           python-version: 3.x
@@ -22042,7 +22042,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - uses: actions/setup-dotnet@v3
         with:
           dotnet-version: 3.x
@@ -22076,7 +22076,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - uses: actions/setup-go@v3
         with:
           go-version: ^1.16.0
@@ -22206,7 +22206,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies

--- a/test/projects/__snapshots__/node.test.ts.snap
+++ b/test/projects/__snapshots__/node.test.ts.snap
@@ -240,7 +240,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - name: Install dependencies
         run: yarn install --check-files
       - name: build
@@ -350,7 +350,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: release
@@ -378,7 +378,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -496,7 +496,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -1556,7 +1556,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - name: Install dependencies
         run: yarn install --check-files
       - name: build
@@ -1737,7 +1737,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -2691,7 +2691,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - name: Install dependencies
         run: yarn install --check-files
       - name: build
@@ -2872,7 +2872,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -3826,7 +3826,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - name: Install dependencies
         run: yarn install --check-files
       - name: build
@@ -4007,7 +4007,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -4962,7 +4962,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - name: Install dependencies
         run: yarn install --check-files
       - name: build
@@ -5072,7 +5072,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: release
@@ -5100,7 +5100,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -5218,7 +5218,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -6246,7 +6246,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - name: Install dependencies
         run: yarn install --check-files
       - name: build
@@ -6356,7 +6356,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: release
@@ -6384,7 +6384,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -6502,7 +6502,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -7530,7 +7530,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - name: Install dependencies
         run: yarn install --check-files
       - name: build
@@ -7640,7 +7640,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: release
@@ -7668,7 +7668,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -7786,7 +7786,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -8814,7 +8814,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - name: Install dependencies
         run: yarn install --check-files
       - name: build
@@ -8924,7 +8924,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: release
@@ -8952,7 +8952,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -9070,7 +9070,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -10098,7 +10098,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - name: Install dependencies
         run: yarn install --check-files
       - name: build
@@ -10208,7 +10208,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: release
@@ -10236,7 +10236,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -10354,7 +10354,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies

--- a/test/projects/__snapshots__/typescript.test.ts.snap
+++ b/test/projects/__snapshots__/typescript.test.ts.snap
@@ -474,7 +474,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - name: Install dependencies
         run: yarn install --check-files
       - name: build
@@ -584,7 +584,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: release
@@ -612,7 +612,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -730,7 +730,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -2214,7 +2214,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - name: Install dependencies
         run: yarn install --check-files
       - name: build
@@ -2395,7 +2395,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -3773,7 +3773,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - name: Install dependencies
         run: yarn install --check-files
       - name: build
@@ -3954,7 +3954,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -5332,7 +5332,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - name: Install dependencies
         run: yarn install --check-files
       - name: build
@@ -5513,7 +5513,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -6892,7 +6892,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - name: Install dependencies
         run: yarn install --check-files
       - name: build
@@ -7002,7 +7002,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: release
@@ -7030,7 +7030,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -7148,7 +7148,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -8600,7 +8600,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - name: Install dependencies
         run: yarn install --check-files
       - name: build
@@ -8710,7 +8710,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: release
@@ -8738,7 +8738,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -8856,7 +8856,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -10308,7 +10308,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - name: Install dependencies
         run: yarn install --check-files
       - name: build
@@ -10418,7 +10418,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: release
@@ -10446,7 +10446,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -10564,7 +10564,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -12016,7 +12016,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - name: Install dependencies
         run: yarn install --check-files
       - name: build
@@ -12126,7 +12126,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: release
@@ -12154,7 +12154,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -12272,7 +12272,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -13724,7 +13724,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - name: Install dependencies
         run: yarn install --check-files
       - name: build
@@ -13834,7 +13834,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: release
@@ -13862,7 +13862,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -13980,7 +13980,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.13.0
+          node-version: 16.20.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies


### PR DESCRIPTION
Currently seeing build errors like,
```
error lru-cache@9.0.1: The engine "node" is incompatible with this module. Expected version "14 || >=16.14". Got "16.13.0"
```

in workflow builds. Example build: https://github.com/cdk8s-team/cdk8s-cli/actions/runs/4673216881/jobs/8276206871?pr=899

This PR is updating the node version for the build.