### PR TITLE
fix(backport): `backport` wasn't being installed as part of the workflow

### DIFF
--- a/src/components/backport/backport.ts
+++ b/src/components/backport/backport.ts
@@ -110,6 +110,7 @@ export class Backport extends Component {
             'fetch-depth': 0,
           },
         },
+        ...project.renderWorkflowSetup({ mutable: false }),
         {
           name: 'Set Git Identity',
           run: 'git config --global user.name "github-actions" && git config --global user.email "github-actions@github.com"',

--- a/test/projects/__snapshots__/jsii.test.ts.snap
+++ b/test/projects/__snapshots__/jsii.test.ts.snap
@@ -442,6 +442,12 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16.20.0
+      - name: Install dependencies
+        run: yarn install --check-files --frozen-lockfile
       - name: Set Git Identity
         run: git config --global user.name \\"github-actions\\" && git config --global user.email \\"github-actions@github.com\\"
       - name: backport

--- a/test/projects/__snapshots__/node.test.ts.snap
+++ b/test/projects/__snapshots__/node.test.ts.snap
@@ -208,6 +208,12 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16.20.0
+      - name: Install dependencies
+        run: yarn install --check-files --frozen-lockfile
       - name: Set Git Identity
         run: git config --global user.name \\"github-actions\\" && git config --global user.email \\"github-actions@github.com\\"
       - name: backport

--- a/test/projects/__snapshots__/typescript.test.ts.snap
+++ b/test/projects/__snapshots__/typescript.test.ts.snap
@@ -442,6 +442,12 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16.20.0
+      - name: Install dependencies
+        run: yarn install --check-files --frozen-lockfile
       - name: Set Git Identity
         run: git config --global user.name \\"github-actions\\" && git config --global user.email \\"github-actions@github.com\\"
       - name: backport


### PR DESCRIPTION
Now that `backport` is defined as a proper dependency, we no longer use `npx` to run it, but it still needs to be installed :)