### PR TITLE
feat: default to node 16

### DIFF
--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -7,7 +7,7 @@
     },
     {
       "name": "@types/node",
-      "version": "^14",
+      "version": "^16",
       "type": "build"
     },
     {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   },
   "devDependencies": {
     "@types/jest": "^27",
-    "@types/node": "^14",
+    "@types/node": "^16",
     "@typescript-eslint/eslint-plugin": "^5",
     "@typescript-eslint/parser": "^5",
     "eslint": "^8",
@@ -70,7 +70,7 @@
     "@types/prettier": "2.6.0"
   },
   "engines": {
-    "node": ">= 14.17.0"
+    "node": ">= 16.20.0"
   },
   "main": "lib/index.js",
   "license": "Apache-2.0",

--- a/src/projects/node.ts
+++ b/src/projects/node.ts
@@ -75,9 +75,8 @@ export function buildNodeProjectDefaultOptions(options: Cdk8sTeamNodeProjectOpti
   return {
     // if release is enabled, default to releasing to npm as well
     releaseToNpm: options.release,
-    minNodeVersion: '14.17.0',
+    minNodeVersion: '16.20.0',
     depsUpgradeOptions,
-    workflowNodeVersion: '16.20.0',
   };
 }
 

--- a/test/projects/__snapshots__/jsii.test.ts.snap
+++ b/test/projects/__snapshots__/jsii.test.ts.snap
@@ -1370,7 +1370,7 @@ tsconfig.tsbuildinfo
       Object {
         "name": "@types/node",
         "type": "build",
-        "version": "^14",
+        "version": "^16",
       },
       Object {
         "name": "@typescript-eslint/eslint-plugin",
@@ -2215,7 +2215,7 @@ echo \\"Configured core.hooksPath to \${hooksdir}\\"
     },
     "devDependencies": Object {
       "@types/jest": "^27",
-      "@types/node": "^14",
+      "@types/node": "^16",
       "@typescript-eslint/eslint-plugin": "^5",
       "@typescript-eslint/parser": "^5",
       "eslint": "^8",
@@ -2235,7 +2235,7 @@ echo \\"Configured core.hooksPath to \${hooksdir}\\"
       "typescript": "*",
     },
     "engines": Object {
-      "node": ">= 14.17.0",
+      "node": ">= 16.20.0",
     },
     "jest": Object {
       "clearMocks": true,
@@ -3295,7 +3295,7 @@ tsconfig.tsbuildinfo
       Object {
         "name": "@types/node",
         "type": "build",
-        "version": "^14",
+        "version": "^16",
       },
       Object {
         "name": "@typescript-eslint/eslint-plugin",
@@ -3989,7 +3989,7 @@ echo \\"Configured core.hooksPath to \${hooksdir}\\"
     },
     "devDependencies": Object {
       "@types/jest": "^27",
-      "@types/node": "^14",
+      "@types/node": "^16",
       "@typescript-eslint/eslint-plugin": "^5",
       "@typescript-eslint/parser": "^5",
       "eslint": "^8",
@@ -4008,7 +4008,7 @@ echo \\"Configured core.hooksPath to \${hooksdir}\\"
       "typescript": "*",
     },
     "engines": Object {
-      "node": ">= 14.17.0",
+      "node": ">= 16.20.0",
     },
     "jest": Object {
       "clearMocks": true,
@@ -5165,7 +5165,7 @@ tsconfig.tsbuildinfo
       Object {
         "name": "@types/node",
         "type": "build",
-        "version": "^14",
+        "version": "^16",
       },
       Object {
         "name": "@typescript-eslint/eslint-plugin",
@@ -5909,7 +5909,7 @@ echo \\"Configured core.hooksPath to \${hooksdir}\\"
     },
     "devDependencies": Object {
       "@types/jest": "^27",
-      "@types/node": "^14",
+      "@types/node": "^16",
       "@typescript-eslint/eslint-plugin": "^5",
       "@typescript-eslint/parser": "^5",
       "eslint": "^8",
@@ -5928,7 +5928,7 @@ echo \\"Configured core.hooksPath to \${hooksdir}\\"
       "typescript": "*",
     },
     "engines": Object {
-      "node": ">= 14.17.0",
+      "node": ">= 16.20.0",
     },
     "jest": Object {
       "clearMocks": true,
@@ -6979,7 +6979,7 @@ tsconfig.tsbuildinfo
       Object {
         "name": "@types/node",
         "type": "build",
-        "version": "^14",
+        "version": "^16",
       },
       Object {
         "name": "@typescript-eslint/eslint-plugin",
@@ -7673,7 +7673,7 @@ echo \\"Configured core.hooksPath to \${hooksdir}\\"
     },
     "devDependencies": Object {
       "@types/jest": "^27",
-      "@types/node": "^14",
+      "@types/node": "^16",
       "@typescript-eslint/eslint-plugin": "^5",
       "@typescript-eslint/parser": "^5",
       "eslint": "^8",
@@ -7692,7 +7692,7 @@ echo \\"Configured core.hooksPath to \${hooksdir}\\"
       "typescript": "*",
     },
     "engines": Object {
-      "node": ">= 14.17.0",
+      "node": ">= 16.20.0",
     },
     "jest": Object {
       "clearMocks": true,
@@ -8849,7 +8849,7 @@ tsconfig.tsbuildinfo
       Object {
         "name": "@types/node",
         "type": "build",
-        "version": "^14",
+        "version": "^16",
       },
       Object {
         "name": "@typescript-eslint/eslint-plugin",
@@ -9593,7 +9593,7 @@ echo \\"Configured core.hooksPath to \${hooksdir}\\"
     },
     "devDependencies": Object {
       "@types/jest": "^27",
-      "@types/node": "^14",
+      "@types/node": "^16",
       "@typescript-eslint/eslint-plugin": "^5",
       "@typescript-eslint/parser": "^5",
       "eslint": "^8",
@@ -9612,7 +9612,7 @@ echo \\"Configured core.hooksPath to \${hooksdir}\\"
       "typescript": "*",
     },
     "engines": Object {
-      "node": ">= 14.17.0",
+      "node": ">= 16.20.0",
     },
     "jest": Object {
       "clearMocks": true,
@@ -10663,7 +10663,7 @@ tsconfig.tsbuildinfo
       Object {
         "name": "@types/node",
         "type": "build",
-        "version": "^14",
+        "version": "^16",
       },
       Object {
         "name": "@typescript-eslint/eslint-plugin",
@@ -11357,7 +11357,7 @@ echo \\"Configured core.hooksPath to \${hooksdir}\\"
     },
     "devDependencies": Object {
       "@types/jest": "^27",
-      "@types/node": "^14",
+      "@types/node": "^16",
       "@typescript-eslint/eslint-plugin": "^5",
       "@typescript-eslint/parser": "^5",
       "eslint": "^8",
@@ -11376,7 +11376,7 @@ echo \\"Configured core.hooksPath to \${hooksdir}\\"
       "typescript": "*",
     },
     "engines": Object {
-      "node": ">= 14.17.0",
+      "node": ">= 16.20.0",
     },
     "jest": Object {
       "clearMocks": true,
@@ -12533,7 +12533,7 @@ tsconfig.tsbuildinfo
       Object {
         "name": "@types/node",
         "type": "build",
-        "version": "^14",
+        "version": "^16",
       },
       Object {
         "name": "@typescript-eslint/eslint-plugin",
@@ -13277,7 +13277,7 @@ echo \\"Configured core.hooksPath to \${hooksdir}\\"
     },
     "devDependencies": Object {
       "@types/jest": "^27",
-      "@types/node": "^14",
+      "@types/node": "^16",
       "@typescript-eslint/eslint-plugin": "^5",
       "@typescript-eslint/parser": "^5",
       "eslint": "^8",
@@ -13296,7 +13296,7 @@ echo \\"Configured core.hooksPath to \${hooksdir}\\"
       "typescript": "*",
     },
     "engines": Object {
-      "node": ">= 14.17.0",
+      "node": ">= 16.20.0",
     },
     "jest": Object {
       "clearMocks": true,
@@ -14770,7 +14770,7 @@ tsconfig.tsbuildinfo
       Object {
         "name": "@types/node",
         "type": "build",
-        "version": "^14",
+        "version": "^16",
       },
       Object {
         "name": "@typescript-eslint/eslint-plugin",
@@ -15589,7 +15589,7 @@ echo \\"Configured core.hooksPath to \${hooksdir}\\"
     },
     "devDependencies": Object {
       "@types/jest": "^27",
-      "@types/node": "^14",
+      "@types/node": "^16",
       "@typescript-eslint/eslint-plugin": "^5",
       "@typescript-eslint/parser": "^5",
       "eslint": "^8",
@@ -15609,7 +15609,7 @@ echo \\"Configured core.hooksPath to \${hooksdir}\\"
       "typescript": "*",
     },
     "engines": Object {
-      "node": ">= 14.17.0",
+      "node": ">= 16.20.0",
     },
     "jest": Object {
       "clearMocks": true,
@@ -17087,7 +17087,7 @@ tsconfig.tsbuildinfo
       Object {
         "name": "@types/node",
         "type": "build",
-        "version": "^14",
+        "version": "^16",
       },
       Object {
         "name": "@typescript-eslint/eslint-plugin",
@@ -17906,7 +17906,7 @@ echo \\"Configured core.hooksPath to \${hooksdir}\\"
     },
     "devDependencies": Object {
       "@types/jest": "^27",
-      "@types/node": "^14",
+      "@types/node": "^16",
       "@typescript-eslint/eslint-plugin": "^5",
       "@typescript-eslint/parser": "^5",
       "eslint": "^8",
@@ -17926,7 +17926,7 @@ echo \\"Configured core.hooksPath to \${hooksdir}\\"
       "typescript": "*",
     },
     "engines": Object {
-      "node": ">= 14.17.0",
+      "node": ">= 16.20.0",
     },
     "jest": Object {
       "clearMocks": true,
@@ -19404,7 +19404,7 @@ tsconfig.tsbuildinfo
       Object {
         "name": "@types/node",
         "type": "build",
-        "version": "^14",
+        "version": "^16",
       },
       Object {
         "name": "@typescript-eslint/eslint-plugin",
@@ -20223,7 +20223,7 @@ echo \\"Configured core.hooksPath to \${hooksdir}\\"
     },
     "devDependencies": Object {
       "@types/jest": "^27",
-      "@types/node": "^14",
+      "@types/node": "^16",
       "@typescript-eslint/eslint-plugin": "^5",
       "@typescript-eslint/parser": "^5",
       "eslint": "^8",
@@ -20243,7 +20243,7 @@ echo \\"Configured core.hooksPath to \${hooksdir}\\"
       "typescript": "*",
     },
     "engines": Object {
-      "node": ">= 14.17.0",
+      "node": ">= 16.20.0",
     },
     "jest": Object {
       "clearMocks": true,
@@ -21721,7 +21721,7 @@ tsconfig.tsbuildinfo
       Object {
         "name": "@types/node",
         "type": "build",
-        "version": "^14",
+        "version": "^16",
       },
       Object {
         "name": "@typescript-eslint/eslint-plugin",
@@ -22540,7 +22540,7 @@ echo \\"Configured core.hooksPath to \${hooksdir}\\"
     },
     "devDependencies": Object {
       "@types/jest": "^27",
-      "@types/node": "^14",
+      "@types/node": "^16",
       "@typescript-eslint/eslint-plugin": "^5",
       "@typescript-eslint/parser": "^5",
       "eslint": "^8",
@@ -22560,7 +22560,7 @@ echo \\"Configured core.hooksPath to \${hooksdir}\\"
       "typescript": "*",
     },
     "engines": Object {
-      "node": ">= 14.17.0",
+      "node": ">= 16.20.0",
     },
     "jest": Object {
       "clearMocks": true,
@@ -24038,7 +24038,7 @@ tsconfig.tsbuildinfo
       Object {
         "name": "@types/node",
         "type": "build",
-        "version": "^14",
+        "version": "^16",
       },
       Object {
         "name": "@typescript-eslint/eslint-plugin",
@@ -24857,7 +24857,7 @@ echo \\"Configured core.hooksPath to \${hooksdir}\\"
     },
     "devDependencies": Object {
       "@types/jest": "^27",
-      "@types/node": "^14",
+      "@types/node": "^16",
       "@typescript-eslint/eslint-plugin": "^5",
       "@typescript-eslint/parser": "^5",
       "eslint": "^8",
@@ -24877,7 +24877,7 @@ echo \\"Configured core.hooksPath to \${hooksdir}\\"
       "typescript": "*",
     },
     "engines": Object {
-      "node": ">= 14.17.0",
+      "node": ">= 16.20.0",
     },
     "jest": Object {
       "clearMocks": true,

--- a/test/projects/__snapshots__/node.test.ts.snap
+++ b/test/projects/__snapshots__/node.test.ts.snap
@@ -1436,7 +1436,7 @@ echo \\"Configured core.hooksPath to \${hooksdir}\\"
       "standard-version": "^9",
     },
     "engines": Object {
-      "node": ">= 14.17.0",
+      "node": ">= 16.20.0",
     },
     "jest": Object {
       "clearMocks": true,
@@ -1704,7 +1704,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 14.18.0
       - name: Install dependencies
         run: yarn install --check-files
       - name: build
@@ -1887,7 +1887,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 14.18.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -1976,7 +1976,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 14.18.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -3988,7 +3988,7 @@ echo \\"Configured core.hooksPath to \${hooksdir}\\"
       "projen": "*",
     },
     "engines": Object {
-      "node": ">= 14.17.0",
+      "node": ">= 16.20.0",
     },
     "jest": Object {
       "clearMocks": true,
@@ -5260,7 +5260,7 @@ echo \\"Configured core.hooksPath to \${hooksdir}\\"
       "projen": "*",
     },
     "engines": Object {
-      "node": ">= 14.17.0",
+      "node": ">= 16.20.0",
     },
     "jest": Object {
       "clearMocks": true,
@@ -6681,7 +6681,7 @@ echo \\"Configured core.hooksPath to \${hooksdir}\\"
       "standard-version": "^9",
     },
     "engines": Object {
-      "node": ">= 14.17.0",
+      "node": ">= 16.20.0",
     },
     "jest": Object {
       "clearMocks": true,
@@ -8105,7 +8105,7 @@ echo \\"Configured core.hooksPath to \${hooksdir}\\"
       "standard-version": "^9",
     },
     "engines": Object {
-      "node": ">= 14.17.0",
+      "node": ">= 16.20.0",
     },
     "jest": Object {
       "clearMocks": true,
@@ -9529,7 +9529,7 @@ echo \\"Configured core.hooksPath to \${hooksdir}\\"
       "standard-version": "^9",
     },
     "engines": Object {
-      "node": ">= 14.17.0",
+      "node": ">= 16.20.0",
     },
     "jest": Object {
       "clearMocks": true,
@@ -10953,7 +10953,7 @@ echo \\"Configured core.hooksPath to \${hooksdir}\\"
       "standard-version": "^9",
     },
     "engines": Object {
-      "node": ">= 14.17.0",
+      "node": ">= 16.20.0",
     },
     "jest": Object {
       "clearMocks": true,
@@ -12377,7 +12377,7 @@ echo \\"Configured core.hooksPath to \${hooksdir}\\"
       "standard-version": "^9",
     },
     "engines": Object {
-      "node": ">= 14.17.0",
+      "node": ">= 16.20.0",
     },
     "jest": Object {
       "clearMocks": true,

--- a/test/projects/__snapshots__/typescript.test.ts.snap
+++ b/test/projects/__snapshots__/typescript.test.ts.snap
@@ -1028,7 +1028,7 @@ tsconfig.tsbuildinfo
       Object {
         "name": "@types/node",
         "type": "build",
-        "version": "^14",
+        "version": "^16",
       },
       Object {
         "name": "@typescript-eslint/eslint-plugin",
@@ -1757,7 +1757,7 @@ echo \\"Configured core.hooksPath to \${hooksdir}\\"
     },
     "devDependencies": Object {
       "@types/jest": "*",
-      "@types/node": "^14",
+      "@types/node": "^16",
       "@typescript-eslint/eslint-plugin": "^5",
       "@typescript-eslint/parser": "^5",
       "eslint": "^8",
@@ -1773,7 +1773,7 @@ echo \\"Configured core.hooksPath to \${hooksdir}\\"
       "typescript": "*",
     },
     "engines": Object {
-      "node": ">= 14.17.0",
+      "node": ">= 16.20.0",
     },
     "jest": Object {
       "clearMocks": true,
@@ -2822,7 +2822,7 @@ tsconfig.tsbuildinfo
       Object {
         "name": "@types/node",
         "type": "build",
-        "version": "^14",
+        "version": "^16",
       },
       Object {
         "name": "@typescript-eslint/eslint-plugin",
@@ -3462,7 +3462,7 @@ echo \\"Configured core.hooksPath to \${hooksdir}\\"
     },
     "devDependencies": Object {
       "@types/jest": "*",
-      "@types/node": "^14",
+      "@types/node": "^16",
       "@typescript-eslint/eslint-plugin": "^5",
       "@typescript-eslint/parser": "^5",
       "eslint": "^8",
@@ -3477,7 +3477,7 @@ echo \\"Configured core.hooksPath to \${hooksdir}\\"
       "typescript": "*",
     },
     "engines": Object {
-      "node": ">= 14.17.0",
+      "node": ">= 16.20.0",
     },
     "jest": Object {
       "clearMocks": true,
@@ -4518,7 +4518,7 @@ tsconfig.tsbuildinfo
       Object {
         "name": "@types/node",
         "type": "build",
-        "version": "^14",
+        "version": "^16",
       },
       Object {
         "name": "@typescript-eslint/eslint-plugin",
@@ -5158,7 +5158,7 @@ echo \\"Configured core.hooksPath to \${hooksdir}\\"
     },
     "devDependencies": Object {
       "@types/jest": "*",
-      "@types/node": "^14",
+      "@types/node": "^16",
       "@typescript-eslint/eslint-plugin": "^5",
       "@typescript-eslint/parser": "^5",
       "eslint": "^8",
@@ -5173,7 +5173,7 @@ echo \\"Configured core.hooksPath to \${hooksdir}\\"
       "typescript": "*",
     },
     "engines": Object {
-      "node": ">= 14.17.0",
+      "node": ">= 16.20.0",
     },
     "jest": Object {
       "clearMocks": true,
@@ -6214,7 +6214,7 @@ tsconfig.tsbuildinfo
       Object {
         "name": "@types/node",
         "type": "build",
-        "version": "^14",
+        "version": "^16",
       },
       Object {
         "name": "@typescript-eslint/eslint-plugin",
@@ -6854,7 +6854,7 @@ echo \\"Configured core.hooksPath to \${hooksdir}\\"
     },
     "devDependencies": Object {
       "@types/jest": "*",
-      "@types/node": "^14",
+      "@types/node": "^16",
       "@typescript-eslint/eslint-plugin": "^5",
       "@typescript-eslint/parser": "^5",
       "eslint": "^8",
@@ -6869,7 +6869,7 @@ echo \\"Configured core.hooksPath to \${hooksdir}\\"
       "typescript": "*",
     },
     "engines": Object {
-      "node": ">= 14.17.0",
+      "node": ">= 16.20.0",
     },
     "jest": Object {
       "clearMocks": true,
@@ -7995,7 +7995,7 @@ tsconfig.tsbuildinfo
       Object {
         "name": "@types/node",
         "type": "build",
-        "version": "^14",
+        "version": "^16",
       },
       Object {
         "name": "@typescript-eslint/eslint-plugin",
@@ -8698,7 +8698,7 @@ echo \\"Configured core.hooksPath to \${hooksdir}\\"
     },
     "devDependencies": Object {
       "@types/jest": "*",
-      "@types/node": "^14",
+      "@types/node": "^16",
       "@typescript-eslint/eslint-plugin": "^5",
       "@typescript-eslint/parser": "^5",
       "eslint": "^8",
@@ -8714,7 +8714,7 @@ echo \\"Configured core.hooksPath to \${hooksdir}\\"
       "typescript": "*",
     },
     "engines": Object {
-      "node": ">= 14.17.0",
+      "node": ">= 16.20.0",
     },
     "jest": Object {
       "clearMocks": true,
@@ -9843,7 +9843,7 @@ tsconfig.tsbuildinfo
       Object {
         "name": "@types/node",
         "type": "build",
-        "version": "^14",
+        "version": "^16",
       },
       Object {
         "name": "@typescript-eslint/eslint-plugin",
@@ -10546,7 +10546,7 @@ echo \\"Configured core.hooksPath to \${hooksdir}\\"
     },
     "devDependencies": Object {
       "@types/jest": "*",
-      "@types/node": "^14",
+      "@types/node": "^16",
       "@typescript-eslint/eslint-plugin": "^5",
       "@typescript-eslint/parser": "^5",
       "eslint": "^8",
@@ -10562,7 +10562,7 @@ echo \\"Configured core.hooksPath to \${hooksdir}\\"
       "typescript": "*",
     },
     "engines": Object {
-      "node": ">= 14.17.0",
+      "node": ">= 16.20.0",
     },
     "jest": Object {
       "clearMocks": true,
@@ -11691,7 +11691,7 @@ tsconfig.tsbuildinfo
       Object {
         "name": "@types/node",
         "type": "build",
-        "version": "^14",
+        "version": "^16",
       },
       Object {
         "name": "@typescript-eslint/eslint-plugin",
@@ -12394,7 +12394,7 @@ echo \\"Configured core.hooksPath to \${hooksdir}\\"
     },
     "devDependencies": Object {
       "@types/jest": "*",
-      "@types/node": "^14",
+      "@types/node": "^16",
       "@typescript-eslint/eslint-plugin": "^5",
       "@typescript-eslint/parser": "^5",
       "eslint": "^8",
@@ -12410,7 +12410,7 @@ echo \\"Configured core.hooksPath to \${hooksdir}\\"
       "typescript": "*",
     },
     "engines": Object {
-      "node": ">= 14.17.0",
+      "node": ">= 16.20.0",
     },
     "jest": Object {
       "clearMocks": true,
@@ -13539,7 +13539,7 @@ tsconfig.tsbuildinfo
       Object {
         "name": "@types/node",
         "type": "build",
-        "version": "^14",
+        "version": "^16",
       },
       Object {
         "name": "@typescript-eslint/eslint-plugin",
@@ -14242,7 +14242,7 @@ echo \\"Configured core.hooksPath to \${hooksdir}\\"
     },
     "devDependencies": Object {
       "@types/jest": "*",
-      "@types/node": "^14",
+      "@types/node": "^16",
       "@typescript-eslint/eslint-plugin": "^5",
       "@typescript-eslint/parser": "^5",
       "eslint": "^8",
@@ -14258,7 +14258,7 @@ echo \\"Configured core.hooksPath to \${hooksdir}\\"
       "typescript": "*",
     },
     "engines": Object {
-      "node": ">= 14.17.0",
+      "node": ">= 16.20.0",
     },
     "jest": Object {
       "clearMocks": true,
@@ -15387,7 +15387,7 @@ tsconfig.tsbuildinfo
       Object {
         "name": "@types/node",
         "type": "build",
-        "version": "^14",
+        "version": "^16",
       },
       Object {
         "name": "@typescript-eslint/eslint-plugin",
@@ -16090,7 +16090,7 @@ echo \\"Configured core.hooksPath to \${hooksdir}\\"
     },
     "devDependencies": Object {
       "@types/jest": "*",
-      "@types/node": "^14",
+      "@types/node": "^16",
       "@typescript-eslint/eslint-plugin": "^5",
       "@typescript-eslint/parser": "^5",
       "eslint": "^8",
@@ -16106,7 +16106,7 @@ echo \\"Configured core.hooksPath to \${hooksdir}\\"
       "typescript": "*",
     },
     "engines": Object {
-      "node": ">= 14.17.0",
+      "node": ">= 16.20.0",
     },
     "jest": Object {
       "clearMocks": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -943,10 +943,10 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-20.3.1.tgz#e8a83f1aa8b649377bb1fb5d7bac5cb90e784dfe"
   integrity sha512-EhcH/wvidPy1WeML3TtYFGR83UzjxeWRen9V402T8aUGYsCHOmfoisV3ZSg03gAFIbLq8TnWOJ0f4cALtnSEUg==
 
-"@types/node@^14":
-  version "14.18.51"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.18.51.tgz#cb90935b89c641201c3d07a595c3e22d1cfaa417"
-  integrity sha512-P9bsdGFPpVtofEKlhWMVS2qqx1A/rt9QBfihWlklfHHpUpjtYse5AzFz6j4DWrARLYh6gRnw9+5+DJcrq3KvBA==
+"@types/node@^16":
+  version "16.18.36"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.18.36.tgz#0db5d7efc4760d36d0d1d22c85d1a53accd5dc27"
+  integrity sha512-8egDX8dE50XyXWH6C6PRCNkTP106DuUrvdrednFouDSmCi7IOvrqr0frznfZaHifHH/3aq/7a7v9N4wdXMqhBQ==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.1"


### PR DESCRIPTION
Now that `constructs` [uses node 16](https://github.com/aws/constructs/blob/10.x/package.json#L73) we are effectively forced to do the same.