### PR TITLE
chore: offset timing of runtime dependency upgrades

### DIFF
--- a/.github/workflows/upgrade-runtime-dependencies-main.yml
+++ b/.github/workflows/upgrade-runtime-dependencies-main.yml
@@ -4,7 +4,7 @@ name: upgrade-runtime-dependencies-main
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: 15 0 * * *
+    - cron: 0 6 * * *
 jobs:
   upgrade:
     name: Upgrade

--- a/.github/workflows/upgrade-runtime-dependencies-main.yml
+++ b/.github/workflows/upgrade-runtime-dependencies-main.yml
@@ -4,7 +4,7 @@ name: upgrade-runtime-dependencies-main
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: 0 0 * * *
+    - cron: 15 0 * * *
 jobs:
   upgrade:
     name: Upgrade

--- a/src/projects/node.ts
+++ b/src/projects/node.ts
@@ -80,7 +80,7 @@ export function buildNodeProjectDefaultOptions(options: Cdk8sTeamNodeProjectOpti
     // only include peer and runtime because we will created a non release trigerring PR for the rest
     types: [DependencyType.PEER, DependencyType.RUNTIME, DependencyType.OPTIONAL],
     workflowOptions: {
-      schedule: UpgradeDependenciesSchedule.expressions(['15 0 * * *']),
+      schedule: UpgradeDependenciesSchedule.expressions(['0 6 * * *']),
     },
   };
 

--- a/src/projects/node.ts
+++ b/src/projects/node.ts
@@ -1,5 +1,5 @@
 import { DependencyType, ReleasableCommits, javascript } from 'projen';
-import { NodeProject, NodeProjectOptions, UpgradeDependencies, UpgradeDependenciesOptions } from 'projen/lib/javascript';
+import { NodeProject, NodeProjectOptions, UpgradeDependencies, UpgradeDependenciesOptions, UpgradeDependenciesSchedule } from 'projen/lib/javascript';
 import { Backport } from '../components/backport/backport';
 import { CodeOfConductMD } from '../components/code-of-conduct/code-of-conduct';
 import { DCO } from '../components/dco/devco';
@@ -79,6 +79,9 @@ export function buildNodeProjectDefaultOptions(options: Cdk8sTeamNodeProjectOpti
     semanticCommit: 'feat',
     // only include peer and runtime because we will created a non release trigerring PR for the rest
     types: [DependencyType.PEER, DependencyType.RUNTIME, DependencyType.OPTIONAL],
+    workflowOptions: {
+      schedule: UpgradeDependenciesSchedule.expressions(['15 0 * * *']),
+    },
   };
 
   return {

--- a/test/projects/__snapshots__/jsii.test.ts.snap
+++ b/test/projects/__snapshots__/jsii.test.ts.snap
@@ -1279,7 +1279,7 @@ name: upgrade-runtime-dependencies-main
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: 0 0 * * *
+    - cron: 15 0 * * *
 jobs:
   upgrade:
     name: Upgrade
@@ -3899,7 +3899,7 @@ name: upgrade-runtime-dependencies-main
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: 0 0 * * *
+    - cron: 15 0 * * *
 jobs:
   upgrade:
     name: Upgrade
@@ -6090,7 +6090,7 @@ name: upgrade-runtime-dependencies
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: 0 0 * * *
+    - cron: 15 0 * * *
 jobs:
   upgrade:
     name: Upgrade
@@ -8196,7 +8196,7 @@ name: upgrade-runtime-dependencies
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: 0 0 * * *
+    - cron: 15 0 * * *
 jobs:
   upgrade:
     name: Upgrade
@@ -10262,7 +10262,7 @@ name: upgrade-runtime-dependencies
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: 0 0 * * *
+    - cron: 15 0 * * *
 jobs:
   upgrade:
     name: Upgrade
@@ -12368,7 +12368,7 @@ name: upgrade-runtime-dependencies
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: 0 0 * * *
+    - cron: 15 0 * * *
 jobs:
   upgrade:
     name: Upgrade
@@ -14434,7 +14434,7 @@ name: upgrade-runtime-dependencies
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: 0 0 * * *
+    - cron: 15 0 * * *
 jobs:
   upgrade:
     name: Upgrade
@@ -16540,7 +16540,7 @@ name: upgrade-runtime-dependencies
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: 0 0 * * *
+    - cron: 15 0 * * *
 jobs:
   upgrade:
     name: Upgrade
@@ -19017,7 +19017,7 @@ name: upgrade-runtime-dependencies-main
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: 0 0 * * *
+    - cron: 15 0 * * *
 jobs:
   upgrade:
     name: Upgrade
@@ -21586,7 +21586,7 @@ name: upgrade-runtime-dependencies-main
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: 0 0 * * *
+    - cron: 15 0 * * *
 jobs:
   upgrade:
     name: Upgrade
@@ -24155,7 +24155,7 @@ name: upgrade-runtime-dependencies-main
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: 0 0 * * *
+    - cron: 15 0 * * *
 jobs:
   upgrade:
     name: Upgrade
@@ -26724,7 +26724,7 @@ name: upgrade-runtime-dependencies-main
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: 0 0 * * *
+    - cron: 15 0 * * *
 jobs:
   upgrade:
     name: Upgrade
@@ -29293,7 +29293,7 @@ name: upgrade-runtime-dependencies-main
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: 0 0 * * *
+    - cron: 15 0 * * *
 jobs:
   upgrade:
     name: Upgrade

--- a/test/projects/__snapshots__/jsii.test.ts.snap
+++ b/test/projects/__snapshots__/jsii.test.ts.snap
@@ -1279,7 +1279,7 @@ name: upgrade-runtime-dependencies-main
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: 15 0 * * *
+    - cron: 0 6 * * *
 jobs:
   upgrade:
     name: Upgrade
@@ -3899,7 +3899,7 @@ name: upgrade-runtime-dependencies-main
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: 15 0 * * *
+    - cron: 0 6 * * *
 jobs:
   upgrade:
     name: Upgrade
@@ -6090,7 +6090,7 @@ name: upgrade-runtime-dependencies
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: 15 0 * * *
+    - cron: 0 6 * * *
 jobs:
   upgrade:
     name: Upgrade
@@ -8196,7 +8196,7 @@ name: upgrade-runtime-dependencies
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: 15 0 * * *
+    - cron: 0 6 * * *
 jobs:
   upgrade:
     name: Upgrade
@@ -10262,7 +10262,7 @@ name: upgrade-runtime-dependencies
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: 15 0 * * *
+    - cron: 0 6 * * *
 jobs:
   upgrade:
     name: Upgrade
@@ -12368,7 +12368,7 @@ name: upgrade-runtime-dependencies
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: 15 0 * * *
+    - cron: 0 6 * * *
 jobs:
   upgrade:
     name: Upgrade
@@ -14434,7 +14434,7 @@ name: upgrade-runtime-dependencies
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: 15 0 * * *
+    - cron: 0 6 * * *
 jobs:
   upgrade:
     name: Upgrade
@@ -16540,7 +16540,7 @@ name: upgrade-runtime-dependencies
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: 15 0 * * *
+    - cron: 0 6 * * *
 jobs:
   upgrade:
     name: Upgrade
@@ -19017,7 +19017,7 @@ name: upgrade-runtime-dependencies-main
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: 15 0 * * *
+    - cron: 0 6 * * *
 jobs:
   upgrade:
     name: Upgrade
@@ -21586,7 +21586,7 @@ name: upgrade-runtime-dependencies-main
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: 15 0 * * *
+    - cron: 0 6 * * *
 jobs:
   upgrade:
     name: Upgrade
@@ -24155,7 +24155,7 @@ name: upgrade-runtime-dependencies-main
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: 15 0 * * *
+    - cron: 0 6 * * *
 jobs:
   upgrade:
     name: Upgrade
@@ -26724,7 +26724,7 @@ name: upgrade-runtime-dependencies-main
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: 15 0 * * *
+    - cron: 0 6 * * *
 jobs:
   upgrade:
     name: Upgrade
@@ -29293,7 +29293,7 @@ name: upgrade-runtime-dependencies-main
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: 15 0 * * *
+    - cron: 0 6 * * *
 jobs:
   upgrade:
     name: Upgrade

--- a/test/projects/__snapshots__/node.test.ts.snap
+++ b/test/projects/__snapshots__/node.test.ts.snap
@@ -675,7 +675,7 @@ name: upgrade-runtime-dependencies-main
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: 15 0 * * *
+    - cron: 0 6 * * *
 jobs:
   upgrade:
     name: Upgrade
@@ -2175,7 +2175,7 @@ name: upgrade-runtime-dependencies
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: 15 0 * * *
+    - cron: 0 6 * * *
 jobs:
   upgrade:
     name: Upgrade
@@ -3565,7 +3565,7 @@ name: upgrade-runtime-dependencies
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: 15 0 * * *
+    - cron: 0 6 * * *
 jobs:
   upgrade:
     name: Upgrade
@@ -4955,7 +4955,7 @@ name: upgrade-runtime-dependencies
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: 15 0 * * *
+    - cron: 0 6 * * *
 jobs:
   upgrade:
     name: Upgrade
@@ -6425,7 +6425,7 @@ name: upgrade-runtime-dependencies-main
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: 15 0 * * *
+    - cron: 0 6 * * *
 jobs:
   upgrade:
     name: Upgrade
@@ -7972,7 +7972,7 @@ name: upgrade-runtime-dependencies-main
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: 15 0 * * *
+    - cron: 0 6 * * *
 jobs:
   upgrade:
     name: Upgrade
@@ -9519,7 +9519,7 @@ name: upgrade-runtime-dependencies-main
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: 15 0 * * *
+    - cron: 0 6 * * *
 jobs:
   upgrade:
     name: Upgrade
@@ -11066,7 +11066,7 @@ name: upgrade-runtime-dependencies-main
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: 15 0 * * *
+    - cron: 0 6 * * *
 jobs:
   upgrade:
     name: Upgrade
@@ -12613,7 +12613,7 @@ name: upgrade-runtime-dependencies-main
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: 15 0 * * *
+    - cron: 0 6 * * *
 jobs:
   upgrade:
     name: Upgrade

--- a/test/projects/__snapshots__/node.test.ts.snap
+++ b/test/projects/__snapshots__/node.test.ts.snap
@@ -675,7 +675,7 @@ name: upgrade-runtime-dependencies-main
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: 0 0 * * *
+    - cron: 15 0 * * *
 jobs:
   upgrade:
     name: Upgrade
@@ -2175,7 +2175,7 @@ name: upgrade-runtime-dependencies
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: 0 0 * * *
+    - cron: 15 0 * * *
 jobs:
   upgrade:
     name: Upgrade
@@ -3565,7 +3565,7 @@ name: upgrade-runtime-dependencies
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: 0 0 * * *
+    - cron: 15 0 * * *
 jobs:
   upgrade:
     name: Upgrade
@@ -4955,7 +4955,7 @@ name: upgrade-runtime-dependencies
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: 0 0 * * *
+    - cron: 15 0 * * *
 jobs:
   upgrade:
     name: Upgrade
@@ -6425,7 +6425,7 @@ name: upgrade-runtime-dependencies-main
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: 0 0 * * *
+    - cron: 15 0 * * *
 jobs:
   upgrade:
     name: Upgrade
@@ -7972,7 +7972,7 @@ name: upgrade-runtime-dependencies-main
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: 0 0 * * *
+    - cron: 15 0 * * *
 jobs:
   upgrade:
     name: Upgrade
@@ -9519,7 +9519,7 @@ name: upgrade-runtime-dependencies-main
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: 0 0 * * *
+    - cron: 15 0 * * *
 jobs:
   upgrade:
     name: Upgrade
@@ -11066,7 +11066,7 @@ name: upgrade-runtime-dependencies-main
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: 0 0 * * *
+    - cron: 15 0 * * *
 jobs:
   upgrade:
     name: Upgrade
@@ -12613,7 +12613,7 @@ name: upgrade-runtime-dependencies-main
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: 0 0 * * *
+    - cron: 15 0 * * *
 jobs:
   upgrade:
     name: Upgrade

--- a/test/projects/__snapshots__/typescript.test.ts.snap
+++ b/test/projects/__snapshots__/typescript.test.ts.snap
@@ -951,7 +951,7 @@ name: upgrade-runtime-dependencies-main
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: 0 0 * * *
+    - cron: 15 0 * * *
 jobs:
   upgrade:
     name: Upgrade
@@ -3096,7 +3096,7 @@ name: upgrade-runtime-dependencies-main
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: 0 0 * * *
+    - cron: 15 0 * * *
 jobs:
   upgrade:
     name: Upgrade
@@ -5140,7 +5140,7 @@ name: upgrade-runtime-dependencies
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: 0 0 * * *
+    - cron: 15 0 * * *
 jobs:
   upgrade:
     name: Upgrade
@@ -7074,7 +7074,7 @@ name: upgrade-runtime-dependencies
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: 0 0 * * *
+    - cron: 15 0 * * *
 jobs:
   upgrade:
     name: Upgrade
@@ -9008,7 +9008,7 @@ name: upgrade-runtime-dependencies
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: 0 0 * * *
+    - cron: 15 0 * * *
 jobs:
   upgrade:
     name: Upgrade
@@ -11025,7 +11025,7 @@ name: upgrade-runtime-dependencies-main
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: 0 0 * * *
+    - cron: 15 0 * * *
 jobs:
   upgrade:
     name: Upgrade
@@ -13119,7 +13119,7 @@ name: upgrade-runtime-dependencies-main
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: 0 0 * * *
+    - cron: 15 0 * * *
 jobs:
   upgrade:
     name: Upgrade
@@ -15213,7 +15213,7 @@ name: upgrade-runtime-dependencies-main
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: 0 0 * * *
+    - cron: 15 0 * * *
 jobs:
   upgrade:
     name: Upgrade
@@ -17307,7 +17307,7 @@ name: upgrade-runtime-dependencies-main
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: 0 0 * * *
+    - cron: 15 0 * * *
 jobs:
   upgrade:
     name: Upgrade
@@ -19401,7 +19401,7 @@ name: upgrade-runtime-dependencies-main
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: 0 0 * * *
+    - cron: 15 0 * * *
 jobs:
   upgrade:
     name: Upgrade

--- a/test/projects/__snapshots__/typescript.test.ts.snap
+++ b/test/projects/__snapshots__/typescript.test.ts.snap
@@ -951,7 +951,7 @@ name: upgrade-runtime-dependencies-main
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: 15 0 * * *
+    - cron: 0 6 * * *
 jobs:
   upgrade:
     name: Upgrade
@@ -3096,7 +3096,7 @@ name: upgrade-runtime-dependencies-main
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: 15 0 * * *
+    - cron: 0 6 * * *
 jobs:
   upgrade:
     name: Upgrade
@@ -5140,7 +5140,7 @@ name: upgrade-runtime-dependencies
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: 15 0 * * *
+    - cron: 0 6 * * *
 jobs:
   upgrade:
     name: Upgrade
@@ -7074,7 +7074,7 @@ name: upgrade-runtime-dependencies
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: 15 0 * * *
+    - cron: 0 6 * * *
 jobs:
   upgrade:
     name: Upgrade
@@ -9008,7 +9008,7 @@ name: upgrade-runtime-dependencies
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: 15 0 * * *
+    - cron: 0 6 * * *
 jobs:
   upgrade:
     name: Upgrade
@@ -11025,7 +11025,7 @@ name: upgrade-runtime-dependencies-main
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: 15 0 * * *
+    - cron: 0 6 * * *
 jobs:
   upgrade:
     name: Upgrade
@@ -13119,7 +13119,7 @@ name: upgrade-runtime-dependencies-main
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: 15 0 * * *
+    - cron: 0 6 * * *
 jobs:
   upgrade:
     name: Upgrade
@@ -15213,7 +15213,7 @@ name: upgrade-runtime-dependencies-main
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: 15 0 * * *
+    - cron: 0 6 * * *
 jobs:
   upgrade:
     name: Upgrade
@@ -17307,7 +17307,7 @@ name: upgrade-runtime-dependencies-main
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: 15 0 * * *
+    - cron: 0 6 * * *
 jobs:
   upgrade:
     name: Upgrade
@@ -19401,7 +19401,7 @@ name: upgrade-runtime-dependencies-main
 on:
   workflow_dispatch: {}
   schedule:
-    - cron: 15 0 * * *
+    - cron: 0 6 * * *
 jobs:
   upgrade:
     name: Upgrade


### PR DESCRIPTION
We are seeing failures in these actions because they are on the same schedule as dev dependency upgrades. The dev dependency upgrades finish slightly faster and cause these to fail because the version required for cdk8s is higher than the dependency upgrade in this workflow.

This PR offsets this upgrade by fifteen minutes.

See [example workflow run](https://github.com/cdk8s-team/cdk8s-postgres/actions/runs/5660984217/job/15337905770).