### PR TITLE
fix: dependency upgrades were released as minor versions

### DIFF
--- a/.github/workflows/upgrade-compiler-dependencies-main.yml
+++ b/.github/workflows/upgrade-compiler-dependencies-main.yml
@@ -66,7 +66,7 @@ jobs:
         with:
           token: ${{ secrets.PROJEN_GITHUB_TOKEN }}
           commit-message: |-
-            feat(deps): upgrade compiler dependencies
+            chore(deps): upgrade compiler dependencies
 
             Upgrades project dependencies. See details in [workflow run].
 
@@ -76,7 +76,7 @@ jobs:
 
             *Automatically created by projen via the "upgrade-compiler-dependencies-main" workflow*
           branch: github-actions/upgrade-compiler-dependencies-main
-          title: "feat(deps): upgrade compiler dependencies"
+          title: "chore(deps): upgrade compiler dependencies"
           labels: auto-approve
           body: |-
             Upgrades project dependencies. See details in [workflow run].

--- a/.github/workflows/upgrade-runtime-dependencies-main.yml
+++ b/.github/workflows/upgrade-runtime-dependencies-main.yml
@@ -66,7 +66,7 @@ jobs:
         with:
           token: ${{ secrets.PROJEN_GITHUB_TOKEN }}
           commit-message: |-
-            feat(deps): upgrade runtime dependencies
+            chore(deps): upgrade runtime dependencies
 
             Upgrades project dependencies. See details in [workflow run].
 
@@ -76,7 +76,7 @@ jobs:
 
             *Automatically created by projen via the "upgrade-runtime-dependencies-main" workflow*
           branch: github-actions/upgrade-runtime-dependencies-main
-          title: "feat(deps): upgrade runtime dependencies"
+          title: "chore(deps): upgrade runtime dependencies"
           labels: auto-approve
           body: |-
             Upgrades project dependencies. See details in [workflow run].

--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -33,7 +33,7 @@
         "BUMPFILE": "dist/version.txt",
         "RELEASETAG": "dist/releasetag.txt",
         "RELEASE_TAG_PREFIX": "",
-        "RELEASABLE_COMMITS": "git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\\([^()[:space:]]+\\))?(!)?:[[:blank:]]+.+'"
+        "RELEASABLE_COMMITS": "git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\\([^()[:space:]]+\\))?(!)?:[[:blank:]]+.+' --grep chore\\(deps\\): upgrade runtime dependencies --grep chore\\(deps\\): upgrade compiler dependencies"
       },
       "steps": [
         {
@@ -253,7 +253,7 @@
         "BUMPFILE": "dist/version.txt",
         "RELEASETAG": "dist/releasetag.txt",
         "RELEASE_TAG_PREFIX": "",
-        "RELEASABLE_COMMITS": "git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\\([^()[:space:]]+\\))?(!)?:[[:blank:]]+.+'"
+        "RELEASABLE_COMMITS": "git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\\([^()[:space:]]+\\))?(!)?:[[:blank:]]+.+' --grep chore\\(deps\\): upgrade runtime dependencies --grep chore\\(deps\\): upgrade compiler dependencies"
       },
       "steps": [
         {

--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -33,7 +33,7 @@
         "BUMPFILE": "dist/version.txt",
         "RELEASETAG": "dist/releasetag.txt",
         "RELEASE_TAG_PREFIX": "",
-        "RELEASABLE_COMMITS": "git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\\([^()[:space:]]+\\))?(!)?:[[:blank:]]+.+' --grep chore\\(deps\\): upgrade runtime dependencies --grep chore\\(deps\\): upgrade compiler dependencies"
+        "RELEASABLE_COMMITS": "git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\\([^()[:space:]]+\\))?(!)?:[[:blank:]]+.+' --grep 'chore\\(deps\\): upgrade runtime dependencies' --grep 'chore\\(deps\\): upgrade compiler dependencies'"
       },
       "steps": [
         {
@@ -253,7 +253,7 @@
         "BUMPFILE": "dist/version.txt",
         "RELEASETAG": "dist/releasetag.txt",
         "RELEASE_TAG_PREFIX": "",
-        "RELEASABLE_COMMITS": "git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\\([^()[:space:]]+\\))?(!)?:[[:blank:]]+.+' --grep chore\\(deps\\): upgrade runtime dependencies --grep chore\\(deps\\): upgrade compiler dependencies"
+        "RELEASABLE_COMMITS": "git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\\([^()[:space:]]+\\))?(!)?:[[:blank:]]+.+' --grep 'chore\\(deps\\): upgrade runtime dependencies' --grep 'chore\\(deps\\): upgrade compiler dependencies'"
       },
       "steps": [
         {

--- a/src/projects/node.ts
+++ b/src/projects/node.ts
@@ -60,8 +60,8 @@ export function buildNodeProjectFixedOptions(options: Cdk8sTeamNodeProjectOption
 
     // runtime and compiler dependencies should trigger a release because
     // they have the potential to change the published artifact.
-    'chore\\(deps\\): upgrade runtime dependencies',
-    'chore\\(deps\\): upgrade compiler dependencies',
+    "'chore\\(deps\\): upgrade runtime dependencies'",
+    "'chore\\(deps\\): upgrade compiler dependencies'",
   ];
 
   return {

--- a/src/projects/node.ts
+++ b/src/projects/node.ts
@@ -55,6 +55,15 @@ export type defaultOptionsKeysType = typeof defaultOptionsKeys[number];
  */
 export function buildNodeProjectFixedOptions(options: Cdk8sTeamNodeProjectOptions): Pick<javascript.NodeProjectOptions, fixedOptionsKeysType> {
 
+  const releasableCommitsCmd = [
+    ReleasableCommits.featuresAndFixes().cmd,
+
+    // runtime and compiler dependencies should trigger a release because
+    // they have the potential to change the published artifact.
+    'chore\\(deps\\): upgrade runtime dependencies',
+    'chore\\(deps\\): upgrade compiler dependencies',
+  ];
+
   return {
     authorName: 'Amazon Web Services',
     repository: `https://github.com/cdk8s-team/${options.repoName ?? buildRepositoryName(options.name)}.git`,
@@ -64,7 +73,7 @@ export function buildNodeProjectFixedOptions(options: Cdk8sTeamNodeProjectOption
     },
     autoApproveUpgrades: true,
     releaseWorkflow: options.release,
-    releasableCommits: ReleasableCommits.featuresAndFixes(),
+    releasableCommits: ReleasableCommits.exec(releasableCommitsCmd.join(' --grep ')),
   };
 }
 
@@ -76,7 +85,6 @@ export function buildNodeProjectDefaultOptions(options: Cdk8sTeamNodeProjectOpti
   const depsUpgradeOptions: UpgradeDependenciesOptions = {
     taskName: 'upgrade-runtime-dependencies',
     pullRequestTitle: 'upgrade runtime dependencies',
-    semanticCommit: 'feat',
     // only include peer and runtime because we will created a non release trigerring PR for the rest
     types: [DependencyType.PEER, DependencyType.RUNTIME, DependencyType.OPTIONAL],
     workflowOptions: {
@@ -252,9 +260,6 @@ export function addComponents(project: NodeProject, repoName: string, branches?:
       include: compilerDeps,
       taskName: 'upgrade-compiler-dependencies',
       pullRequestTitle: 'upgrade compiler dependencies',
-      // compiler dependencies should trigger a release because they change
-      // the published artifact.
-      semanticCommit: 'feat',
       workflowOptions: {
         branches,
         labels: ['auto-approve'],

--- a/test/projects/__snapshots__/jsii.test.ts.snap
+++ b/test/projects/__snapshots__/jsii.test.ts.snap
@@ -1065,7 +1065,7 @@ jobs:
         with:
           token: \${{ secrets.PROJEN_GITHUB_TOKEN }}
           commit-message: |-
-            feat(deps): upgrade compiler dependencies
+            chore(deps): upgrade compiler dependencies
 
             Upgrades project dependencies. See details in [workflow run].
 
@@ -1075,7 +1075,7 @@ jobs:
 
             *Automatically created by projen via the \\"upgrade-compiler-dependencies-main\\" workflow*
           branch: github-actions/upgrade-compiler-dependencies-main
-          title: \\"feat(deps): upgrade compiler dependencies\\"
+          title: \\"chore(deps): upgrade compiler dependencies\\"
           labels: auto-approve
           body: |-
             Upgrades project dependencies. See details in [workflow run].
@@ -1341,7 +1341,7 @@ jobs:
         with:
           token: \${{ secrets.PROJEN_GITHUB_TOKEN }}
           commit-message: |-
-            feat(deps): upgrade runtime dependencies
+            chore(deps): upgrade runtime dependencies
 
             Upgrades project dependencies. See details in [workflow run].
 
@@ -1351,7 +1351,7 @@ jobs:
 
             *Automatically created by projen via the \\"upgrade-runtime-dependencies-main\\" workflow*
           branch: github-actions/upgrade-runtime-dependencies-main
-          title: \\"feat(deps): upgrade runtime dependencies\\"
+          title: \\"chore(deps): upgrade runtime dependencies\\"
           labels: auto-approve
           body: |-
             Upgrades project dependencies. See details in [workflow run].
@@ -1675,7 +1675,7 @@ tsconfig.tsbuildinfo
           "BUMPFILE": "dist/version.txt",
           "CHANGELOG": "dist/changelog.md",
           "OUTFILE": "package.json",
-          "RELEASABLE_COMMITS": "git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\\\\([^()[:space:]]+\\\\))?(!)?:[[:blank:]]+.+'",
+          "RELEASABLE_COMMITS": "git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\\\\([^()[:space:]]+\\\\))?(!)?:[[:blank:]]+.+' --grep 'chore\\\\(deps\\\\): upgrade runtime dependencies' --grep 'chore\\\\(deps\\\\): upgrade compiler dependencies'",
           "RELEASETAG": "dist/releasetag.txt",
           "RELEASE_TAG_PREFIX": "",
         },
@@ -1939,7 +1939,7 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
           "BUMPFILE": "dist/version.txt",
           "CHANGELOG": "dist/changelog.md",
           "OUTFILE": "package.json",
-          "RELEASABLE_COMMITS": "git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\\\\([^()[:space:]]+\\\\))?(!)?:[[:blank:]]+.+'",
+          "RELEASABLE_COMMITS": "git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\\\\([^()[:space:]]+\\\\))?(!)?:[[:blank:]]+.+' --grep 'chore\\\\(deps\\\\): upgrade runtime dependencies' --grep 'chore\\\\(deps\\\\): upgrade compiler dependencies'",
           "RELEASETAG": "dist/releasetag.txt",
           "RELEASE_TAG_PREFIX": "",
         },
@@ -3649,7 +3649,7 @@ jobs:
         with:
           token: \${{ secrets.PROJEN_GITHUB_TOKEN }}
           commit-message: |-
-            feat(deps): upgrade compiler dependencies
+            chore(deps): upgrade compiler dependencies
 
             Upgrades project dependencies. See details in [workflow run].
 
@@ -3659,7 +3659,7 @@ jobs:
 
             *Automatically created by projen via the \\"upgrade-compiler-dependencies-main\\" workflow*
           branch: github-actions/upgrade-compiler-dependencies-main
-          title: \\"feat(deps): upgrade compiler dependencies\\"
+          title: \\"chore(deps): upgrade compiler dependencies\\"
           labels: auto-approve
           body: |-
             Upgrades project dependencies. See details in [workflow run].
@@ -3925,7 +3925,7 @@ jobs:
         with:
           token: \${{ secrets.PROJEN_GITHUB_TOKEN }}
           commit-message: |-
-            feat(deps): upgrade runtime dependencies
+            chore(deps): upgrade runtime dependencies
 
             Upgrades project dependencies. See details in [workflow run].
 
@@ -3935,7 +3935,7 @@ jobs:
 
             *Automatically created by projen via the \\"upgrade-runtime-dependencies-main\\" workflow*
           branch: github-actions/upgrade-runtime-dependencies-main
-          title: \\"feat(deps): upgrade runtime dependencies\\"
+          title: \\"chore(deps): upgrade runtime dependencies\\"
           labels: auto-approve
           body: |-
             Upgrades project dependencies. See details in [workflow run].
@@ -4287,7 +4287,7 @@ tsconfig.tsbuildinfo
           "BUMPFILE": "dist/version.txt",
           "CHANGELOG": "dist/changelog.md",
           "OUTFILE": "package.json",
-          "RELEASABLE_COMMITS": "git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\\\\([^()[:space:]]+\\\\))?(!)?:[[:blank:]]+.+'",
+          "RELEASABLE_COMMITS": "git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\\\\([^()[:space:]]+\\\\))?(!)?:[[:blank:]]+.+' --grep 'chore\\\\(deps\\\\): upgrade runtime dependencies' --grep 'chore\\\\(deps\\\\): upgrade compiler dependencies'",
           "RELEASETAG": "dist/releasetag.txt",
           "RELEASE_TAG_PREFIX": "",
         },
@@ -4551,7 +4551,7 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
           "BUMPFILE": "dist/version.txt",
           "CHANGELOG": "dist/changelog.md",
           "OUTFILE": "package.json",
-          "RELEASABLE_COMMITS": "git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\\\\([^()[:space:]]+\\\\))?(!)?:[[:blank:]]+.+'",
+          "RELEASABLE_COMMITS": "git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\\\\([^()[:space:]]+\\\\))?(!)?:[[:blank:]]+.+' --grep 'chore\\\\(deps\\\\): upgrade runtime dependencies' --grep 'chore\\\\(deps\\\\): upgrade compiler dependencies'",
           "RELEASETAG": "dist/releasetag.txt",
           "RELEASE_TAG_PREFIX": "",
         },
@@ -5810,7 +5810,7 @@ jobs:
         with:
           token: \${{ secrets.PROJEN_GITHUB_TOKEN }}
           commit-message: |-
-            feat(deps): upgrade compiler dependencies
+            chore(deps): upgrade compiler dependencies
 
             Upgrades project dependencies. See details in [workflow run].
 
@@ -5820,7 +5820,7 @@ jobs:
 
             *Automatically created by projen via the \\"upgrade-compiler-dependencies\\" workflow*
           branch: github-actions/upgrade-compiler-dependencies
-          title: \\"feat(deps): upgrade compiler dependencies\\"
+          title: \\"chore(deps): upgrade compiler dependencies\\"
           labels: auto-approve
           body: |-
             Upgrades project dependencies. See details in [workflow run].
@@ -6077,7 +6077,7 @@ jobs:
         with:
           token: \${{ secrets.PROJEN_GITHUB_TOKEN }}
           commit-message: |-
-            feat(deps): upgrade runtime dependencies
+            chore(deps): upgrade runtime dependencies
 
             Upgrades project dependencies. See details in [workflow run].
 
@@ -6087,7 +6087,7 @@ jobs:
 
             *Automatically created by projen via the \\"upgrade-runtime-dependencies\\" workflow*
           branch: github-actions/upgrade-runtime-dependencies
-          title: \\"feat(deps): upgrade runtime dependencies\\"
+          title: \\"chore(deps): upgrade runtime dependencies\\"
           labels: auto-approve
           body: |-
             Upgrades project dependencies. See details in [workflow run].
@@ -7880,7 +7880,7 @@ jobs:
         with:
           token: \${{ secrets.PROJEN_GITHUB_TOKEN }}
           commit-message: |-
-            feat(deps): upgrade compiler dependencies
+            chore(deps): upgrade compiler dependencies
 
             Upgrades project dependencies. See details in [workflow run].
 
@@ -7890,7 +7890,7 @@ jobs:
 
             *Automatically created by projen via the \\"upgrade-compiler-dependencies\\" workflow*
           branch: github-actions/upgrade-compiler-dependencies
-          title: \\"feat(deps): upgrade compiler dependencies\\"
+          title: \\"chore(deps): upgrade compiler dependencies\\"
           labels: auto-approve
           body: |-
             Upgrades project dependencies. See details in [workflow run].
@@ -8147,7 +8147,7 @@ jobs:
         with:
           token: \${{ secrets.PROJEN_GITHUB_TOKEN }}
           commit-message: |-
-            feat(deps): upgrade runtime dependencies
+            chore(deps): upgrade runtime dependencies
 
             Upgrades project dependencies. See details in [workflow run].
 
@@ -8157,7 +8157,7 @@ jobs:
 
             *Automatically created by projen via the \\"upgrade-runtime-dependencies\\" workflow*
           branch: github-actions/upgrade-runtime-dependencies
-          title: \\"feat(deps): upgrade runtime dependencies\\"
+          title: \\"chore(deps): upgrade runtime dependencies\\"
           labels: auto-approve
           body: |-
             Upgrades project dependencies. See details in [workflow run].
@@ -9910,7 +9910,7 @@ jobs:
         with:
           token: \${{ secrets.PROJEN_GITHUB_TOKEN }}
           commit-message: |-
-            feat(deps): upgrade compiler dependencies
+            chore(deps): upgrade compiler dependencies
 
             Upgrades project dependencies. See details in [workflow run].
 
@@ -9920,7 +9920,7 @@ jobs:
 
             *Automatically created by projen via the \\"upgrade-compiler-dependencies\\" workflow*
           branch: github-actions/upgrade-compiler-dependencies
-          title: \\"feat(deps): upgrade compiler dependencies\\"
+          title: \\"chore(deps): upgrade compiler dependencies\\"
           labels: auto-approve
           body: |-
             Upgrades project dependencies. See details in [workflow run].
@@ -10177,7 +10177,7 @@ jobs:
         with:
           token: \${{ secrets.PROJEN_GITHUB_TOKEN }}
           commit-message: |-
-            feat(deps): upgrade runtime dependencies
+            chore(deps): upgrade runtime dependencies
 
             Upgrades project dependencies. See details in [workflow run].
 
@@ -10187,7 +10187,7 @@ jobs:
 
             *Automatically created by projen via the \\"upgrade-runtime-dependencies\\" workflow*
           branch: github-actions/upgrade-runtime-dependencies
-          title: \\"feat(deps): upgrade runtime dependencies\\"
+          title: \\"chore(deps): upgrade runtime dependencies\\"
           labels: auto-approve
           body: |-
             Upgrades project dependencies. See details in [workflow run].
@@ -11980,7 +11980,7 @@ jobs:
         with:
           token: \${{ secrets.PROJEN_GITHUB_TOKEN }}
           commit-message: |-
-            feat(deps): upgrade compiler dependencies
+            chore(deps): upgrade compiler dependencies
 
             Upgrades project dependencies. See details in [workflow run].
 
@@ -11990,7 +11990,7 @@ jobs:
 
             *Automatically created by projen via the \\"upgrade-compiler-dependencies\\" workflow*
           branch: github-actions/upgrade-compiler-dependencies
-          title: \\"feat(deps): upgrade compiler dependencies\\"
+          title: \\"chore(deps): upgrade compiler dependencies\\"
           labels: auto-approve
           body: |-
             Upgrades project dependencies. See details in [workflow run].
@@ -12247,7 +12247,7 @@ jobs:
         with:
           token: \${{ secrets.PROJEN_GITHUB_TOKEN }}
           commit-message: |-
-            feat(deps): upgrade runtime dependencies
+            chore(deps): upgrade runtime dependencies
 
             Upgrades project dependencies. See details in [workflow run].
 
@@ -12257,7 +12257,7 @@ jobs:
 
             *Automatically created by projen via the \\"upgrade-runtime-dependencies\\" workflow*
           branch: github-actions/upgrade-runtime-dependencies
-          title: \\"feat(deps): upgrade runtime dependencies\\"
+          title: \\"chore(deps): upgrade runtime dependencies\\"
           labels: auto-approve
           body: |-
             Upgrades project dependencies. See details in [workflow run].
@@ -14010,7 +14010,7 @@ jobs:
         with:
           token: \${{ secrets.PROJEN_GITHUB_TOKEN }}
           commit-message: |-
-            feat(deps): upgrade compiler dependencies
+            chore(deps): upgrade compiler dependencies
 
             Upgrades project dependencies. See details in [workflow run].
 
@@ -14020,7 +14020,7 @@ jobs:
 
             *Automatically created by projen via the \\"upgrade-compiler-dependencies\\" workflow*
           branch: github-actions/upgrade-compiler-dependencies
-          title: \\"feat(deps): upgrade compiler dependencies\\"
+          title: \\"chore(deps): upgrade compiler dependencies\\"
           labels: auto-approve
           body: |-
             Upgrades project dependencies. See details in [workflow run].
@@ -14277,7 +14277,7 @@ jobs:
         with:
           token: \${{ secrets.PROJEN_GITHUB_TOKEN }}
           commit-message: |-
-            feat(deps): upgrade runtime dependencies
+            chore(deps): upgrade runtime dependencies
 
             Upgrades project dependencies. See details in [workflow run].
 
@@ -14287,7 +14287,7 @@ jobs:
 
             *Automatically created by projen via the \\"upgrade-runtime-dependencies\\" workflow*
           branch: github-actions/upgrade-runtime-dependencies
-          title: \\"feat(deps): upgrade runtime dependencies\\"
+          title: \\"chore(deps): upgrade runtime dependencies\\"
           labels: auto-approve
           body: |-
             Upgrades project dependencies. See details in [workflow run].
@@ -16080,7 +16080,7 @@ jobs:
         with:
           token: \${{ secrets.PROJEN_GITHUB_TOKEN }}
           commit-message: |-
-            feat(deps): upgrade compiler dependencies
+            chore(deps): upgrade compiler dependencies
 
             Upgrades project dependencies. See details in [workflow run].
 
@@ -16090,7 +16090,7 @@ jobs:
 
             *Automatically created by projen via the \\"upgrade-compiler-dependencies\\" workflow*
           branch: github-actions/upgrade-compiler-dependencies
-          title: \\"feat(deps): upgrade compiler dependencies\\"
+          title: \\"chore(deps): upgrade compiler dependencies\\"
           labels: auto-approve
           body: |-
             Upgrades project dependencies. See details in [workflow run].
@@ -16347,7 +16347,7 @@ jobs:
         with:
           token: \${{ secrets.PROJEN_GITHUB_TOKEN }}
           commit-message: |-
-            feat(deps): upgrade runtime dependencies
+            chore(deps): upgrade runtime dependencies
 
             Upgrades project dependencies. See details in [workflow run].
 
@@ -16357,7 +16357,7 @@ jobs:
 
             *Automatically created by projen via the \\"upgrade-runtime-dependencies\\" workflow*
           branch: github-actions/upgrade-runtime-dependencies
-          title: \\"feat(deps): upgrade runtime dependencies\\"
+          title: \\"chore(deps): upgrade runtime dependencies\\"
           labels: auto-approve
           body: |-
             Upgrades project dependencies. See details in [workflow run].
@@ -18515,7 +18515,7 @@ jobs:
         with:
           token: \${{ secrets.PROJEN_GITHUB_TOKEN }}
           commit-message: |-
-            feat(deps): upgrade compiler dependencies
+            chore(deps): upgrade compiler dependencies
 
             Upgrades project dependencies. See details in [workflow run].
 
@@ -18525,7 +18525,7 @@ jobs:
 
             *Automatically created by projen via the \\"upgrade-compiler-dependencies-main\\" workflow*
           branch: github-actions/upgrade-compiler-dependencies-main
-          title: \\"feat(deps): upgrade compiler dependencies\\"
+          title: \\"chore(deps): upgrade compiler dependencies\\"
           labels: auto-approve
           body: |-
             Upgrades project dependencies. See details in [workflow run].
@@ -18791,7 +18791,7 @@ jobs:
         with:
           token: \${{ secrets.PROJEN_GITHUB_TOKEN }}
           commit-message: |-
-            feat(deps): upgrade runtime dependencies
+            chore(deps): upgrade runtime dependencies
 
             Upgrades project dependencies. See details in [workflow run].
 
@@ -18801,7 +18801,7 @@ jobs:
 
             *Automatically created by projen via the \\"upgrade-runtime-dependencies-main\\" workflow*
           branch: github-actions/upgrade-runtime-dependencies-main
-          title: \\"feat(deps): upgrade runtime dependencies\\"
+          title: \\"chore(deps): upgrade runtime dependencies\\"
           labels: auto-approve
           body: |-
             Upgrades project dependencies. See details in [workflow run].
@@ -19125,7 +19125,7 @@ tsconfig.tsbuildinfo
           "BUMPFILE": "dist/version.txt",
           "CHANGELOG": "dist/changelog.md",
           "OUTFILE": "package.json",
-          "RELEASABLE_COMMITS": "git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\\\\([^()[:space:]]+\\\\))?(!)?:[[:blank:]]+.+'",
+          "RELEASABLE_COMMITS": "git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\\\\([^()[:space:]]+\\\\))?(!)?:[[:blank:]]+.+' --grep 'chore\\\\(deps\\\\): upgrade runtime dependencies' --grep 'chore\\\\(deps\\\\): upgrade compiler dependencies'",
           "RELEASETAG": "dist/releasetag.txt",
           "RELEASE_TAG_PREFIX": "",
         },
@@ -19389,7 +19389,7 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
           "BUMPFILE": "dist/version.txt",
           "CHANGELOG": "dist/changelog.md",
           "OUTFILE": "package.json",
-          "RELEASABLE_COMMITS": "git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\\\\([^()[:space:]]+\\\\))?(!)?:[[:blank:]]+.+'",
+          "RELEASABLE_COMMITS": "git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\\\\([^()[:space:]]+\\\\))?(!)?:[[:blank:]]+.+' --grep 'chore\\\\(deps\\\\): upgrade runtime dependencies' --grep 'chore\\\\(deps\\\\): upgrade compiler dependencies'",
           "RELEASETAG": "dist/releasetag.txt",
           "RELEASE_TAG_PREFIX": "",
         },
@@ -21048,7 +21048,7 @@ jobs:
         with:
           token: \${{ secrets.PROJEN_GITHUB_TOKEN }}
           commit-message: |-
-            feat(deps): upgrade compiler dependencies
+            chore(deps): upgrade compiler dependencies
 
             Upgrades project dependencies. See details in [workflow run].
 
@@ -21058,7 +21058,7 @@ jobs:
 
             *Automatically created by projen via the \\"upgrade-compiler-dependencies-main\\" workflow*
           branch: github-actions/upgrade-compiler-dependencies-main
-          title: \\"feat(deps): upgrade compiler dependencies\\"
+          title: \\"chore(deps): upgrade compiler dependencies\\"
           labels: auto-approve
           body: |-
             Upgrades project dependencies. See details in [workflow run].
@@ -21324,7 +21324,7 @@ jobs:
         with:
           token: \${{ secrets.PROJEN_GITHUB_TOKEN }}
           commit-message: |-
-            feat(deps): upgrade runtime dependencies
+            chore(deps): upgrade runtime dependencies
 
             Upgrades project dependencies. See details in [workflow run].
 
@@ -21334,7 +21334,7 @@ jobs:
 
             *Automatically created by projen via the \\"upgrade-runtime-dependencies-main\\" workflow*
           branch: github-actions/upgrade-runtime-dependencies-main
-          title: \\"feat(deps): upgrade runtime dependencies\\"
+          title: \\"chore(deps): upgrade runtime dependencies\\"
           labels: auto-approve
           body: |-
             Upgrades project dependencies. See details in [workflow run].
@@ -21658,7 +21658,7 @@ tsconfig.tsbuildinfo
           "BUMPFILE": "dist/version.txt",
           "CHANGELOG": "dist/changelog.md",
           "OUTFILE": "package.json",
-          "RELEASABLE_COMMITS": "git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\\\\([^()[:space:]]+\\\\))?(!)?:[[:blank:]]+.+'",
+          "RELEASABLE_COMMITS": "git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\\\\([^()[:space:]]+\\\\))?(!)?:[[:blank:]]+.+' --grep 'chore\\\\(deps\\\\): upgrade runtime dependencies' --grep 'chore\\\\(deps\\\\): upgrade compiler dependencies'",
           "RELEASETAG": "dist/releasetag.txt",
           "RELEASE_TAG_PREFIX": "",
         },
@@ -21922,7 +21922,7 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
           "BUMPFILE": "dist/version.txt",
           "CHANGELOG": "dist/changelog.md",
           "OUTFILE": "package.json",
-          "RELEASABLE_COMMITS": "git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\\\\([^()[:space:]]+\\\\))?(!)?:[[:blank:]]+.+'",
+          "RELEASABLE_COMMITS": "git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\\\\([^()[:space:]]+\\\\))?(!)?:[[:blank:]]+.+' --grep 'chore\\\\(deps\\\\): upgrade runtime dependencies' --grep 'chore\\\\(deps\\\\): upgrade compiler dependencies'",
           "RELEASETAG": "dist/releasetag.txt",
           "RELEASE_TAG_PREFIX": "",
         },
@@ -23581,7 +23581,7 @@ jobs:
         with:
           token: \${{ secrets.PROJEN_GITHUB_TOKEN }}
           commit-message: |-
-            feat(deps): upgrade compiler dependencies
+            chore(deps): upgrade compiler dependencies
 
             Upgrades project dependencies. See details in [workflow run].
 
@@ -23591,7 +23591,7 @@ jobs:
 
             *Automatically created by projen via the \\"upgrade-compiler-dependencies-main\\" workflow*
           branch: github-actions/upgrade-compiler-dependencies-main
-          title: \\"feat(deps): upgrade compiler dependencies\\"
+          title: \\"chore(deps): upgrade compiler dependencies\\"
           labels: auto-approve
           body: |-
             Upgrades project dependencies. See details in [workflow run].
@@ -23857,7 +23857,7 @@ jobs:
         with:
           token: \${{ secrets.PROJEN_GITHUB_TOKEN }}
           commit-message: |-
-            feat(deps): upgrade runtime dependencies
+            chore(deps): upgrade runtime dependencies
 
             Upgrades project dependencies. See details in [workflow run].
 
@@ -23867,7 +23867,7 @@ jobs:
 
             *Automatically created by projen via the \\"upgrade-runtime-dependencies-main\\" workflow*
           branch: github-actions/upgrade-runtime-dependencies-main
-          title: \\"feat(deps): upgrade runtime dependencies\\"
+          title: \\"chore(deps): upgrade runtime dependencies\\"
           labels: auto-approve
           body: |-
             Upgrades project dependencies. See details in [workflow run].
@@ -24191,7 +24191,7 @@ tsconfig.tsbuildinfo
           "BUMPFILE": "dist/version.txt",
           "CHANGELOG": "dist/changelog.md",
           "OUTFILE": "package.json",
-          "RELEASABLE_COMMITS": "git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\\\\([^()[:space:]]+\\\\))?(!)?:[[:blank:]]+.+'",
+          "RELEASABLE_COMMITS": "git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\\\\([^()[:space:]]+\\\\))?(!)?:[[:blank:]]+.+' --grep 'chore\\\\(deps\\\\): upgrade runtime dependencies' --grep 'chore\\\\(deps\\\\): upgrade compiler dependencies'",
           "RELEASETAG": "dist/releasetag.txt",
           "RELEASE_TAG_PREFIX": "",
         },
@@ -24455,7 +24455,7 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
           "BUMPFILE": "dist/version.txt",
           "CHANGELOG": "dist/changelog.md",
           "OUTFILE": "package.json",
-          "RELEASABLE_COMMITS": "git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\\\\([^()[:space:]]+\\\\))?(!)?:[[:blank:]]+.+'",
+          "RELEASABLE_COMMITS": "git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\\\\([^()[:space:]]+\\\\))?(!)?:[[:blank:]]+.+' --grep 'chore\\\\(deps\\\\): upgrade runtime dependencies' --grep 'chore\\\\(deps\\\\): upgrade compiler dependencies'",
           "RELEASETAG": "dist/releasetag.txt",
           "RELEASE_TAG_PREFIX": "",
         },
@@ -26114,7 +26114,7 @@ jobs:
         with:
           token: \${{ secrets.PROJEN_GITHUB_TOKEN }}
           commit-message: |-
-            feat(deps): upgrade compiler dependencies
+            chore(deps): upgrade compiler dependencies
 
             Upgrades project dependencies. See details in [workflow run].
 
@@ -26124,7 +26124,7 @@ jobs:
 
             *Automatically created by projen via the \\"upgrade-compiler-dependencies-main\\" workflow*
           branch: github-actions/upgrade-compiler-dependencies-main
-          title: \\"feat(deps): upgrade compiler dependencies\\"
+          title: \\"chore(deps): upgrade compiler dependencies\\"
           labels: auto-approve
           body: |-
             Upgrades project dependencies. See details in [workflow run].
@@ -26390,7 +26390,7 @@ jobs:
         with:
           token: \${{ secrets.PROJEN_GITHUB_TOKEN }}
           commit-message: |-
-            feat(deps): upgrade runtime dependencies
+            chore(deps): upgrade runtime dependencies
 
             Upgrades project dependencies. See details in [workflow run].
 
@@ -26400,7 +26400,7 @@ jobs:
 
             *Automatically created by projen via the \\"upgrade-runtime-dependencies-main\\" workflow*
           branch: github-actions/upgrade-runtime-dependencies-main
-          title: \\"feat(deps): upgrade runtime dependencies\\"
+          title: \\"chore(deps): upgrade runtime dependencies\\"
           labels: auto-approve
           body: |-
             Upgrades project dependencies. See details in [workflow run].
@@ -26724,7 +26724,7 @@ tsconfig.tsbuildinfo
           "BUMPFILE": "dist/version.txt",
           "CHANGELOG": "dist/changelog.md",
           "OUTFILE": "package.json",
-          "RELEASABLE_COMMITS": "git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\\\\([^()[:space:]]+\\\\))?(!)?:[[:blank:]]+.+'",
+          "RELEASABLE_COMMITS": "git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\\\\([^()[:space:]]+\\\\))?(!)?:[[:blank:]]+.+' --grep 'chore\\\\(deps\\\\): upgrade runtime dependencies' --grep 'chore\\\\(deps\\\\): upgrade compiler dependencies'",
           "RELEASETAG": "dist/releasetag.txt",
           "RELEASE_TAG_PREFIX": "",
         },
@@ -26988,7 +26988,7 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
           "BUMPFILE": "dist/version.txt",
           "CHANGELOG": "dist/changelog.md",
           "OUTFILE": "package.json",
-          "RELEASABLE_COMMITS": "git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\\\\([^()[:space:]]+\\\\))?(!)?:[[:blank:]]+.+'",
+          "RELEASABLE_COMMITS": "git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\\\\([^()[:space:]]+\\\\))?(!)?:[[:blank:]]+.+' --grep 'chore\\\\(deps\\\\): upgrade runtime dependencies' --grep 'chore\\\\(deps\\\\): upgrade compiler dependencies'",
           "RELEASETAG": "dist/releasetag.txt",
           "RELEASE_TAG_PREFIX": "",
         },
@@ -28647,7 +28647,7 @@ jobs:
         with:
           token: \${{ secrets.PROJEN_GITHUB_TOKEN }}
           commit-message: |-
-            feat(deps): upgrade compiler dependencies
+            chore(deps): upgrade compiler dependencies
 
             Upgrades project dependencies. See details in [workflow run].
 
@@ -28657,7 +28657,7 @@ jobs:
 
             *Automatically created by projen via the \\"upgrade-compiler-dependencies-main\\" workflow*
           branch: github-actions/upgrade-compiler-dependencies-main
-          title: \\"feat(deps): upgrade compiler dependencies\\"
+          title: \\"chore(deps): upgrade compiler dependencies\\"
           labels: auto-approve
           body: |-
             Upgrades project dependencies. See details in [workflow run].
@@ -28923,7 +28923,7 @@ jobs:
         with:
           token: \${{ secrets.PROJEN_GITHUB_TOKEN }}
           commit-message: |-
-            feat(deps): upgrade runtime dependencies
+            chore(deps): upgrade runtime dependencies
 
             Upgrades project dependencies. See details in [workflow run].
 
@@ -28933,7 +28933,7 @@ jobs:
 
             *Automatically created by projen via the \\"upgrade-runtime-dependencies-main\\" workflow*
           branch: github-actions/upgrade-runtime-dependencies-main
-          title: \\"feat(deps): upgrade runtime dependencies\\"
+          title: \\"chore(deps): upgrade runtime dependencies\\"
           labels: auto-approve
           body: |-
             Upgrades project dependencies. See details in [workflow run].
@@ -29257,7 +29257,7 @@ tsconfig.tsbuildinfo
           "BUMPFILE": "dist/version.txt",
           "CHANGELOG": "dist/changelog.md",
           "OUTFILE": "package.json",
-          "RELEASABLE_COMMITS": "git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\\\\([^()[:space:]]+\\\\))?(!)?:[[:blank:]]+.+'",
+          "RELEASABLE_COMMITS": "git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\\\\([^()[:space:]]+\\\\))?(!)?:[[:blank:]]+.+' --grep 'chore\\\\(deps\\\\): upgrade runtime dependencies' --grep 'chore\\\\(deps\\\\): upgrade compiler dependencies'",
           "RELEASETAG": "dist/releasetag.txt",
           "RELEASE_TAG_PREFIX": "",
         },
@@ -29521,7 +29521,7 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
           "BUMPFILE": "dist/version.txt",
           "CHANGELOG": "dist/changelog.md",
           "OUTFILE": "package.json",
-          "RELEASABLE_COMMITS": "git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\\\\([^()[:space:]]+\\\\))?(!)?:[[:blank:]]+.+'",
+          "RELEASABLE_COMMITS": "git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\\\\([^()[:space:]]+\\\\))?(!)?:[[:blank:]]+.+' --grep 'chore\\\\(deps\\\\): upgrade runtime dependencies' --grep 'chore\\\\(deps\\\\): upgrade compiler dependencies'",
           "RELEASETAG": "dist/releasetag.txt",
           "RELEASE_TAG_PREFIX": "",
         },

--- a/test/projects/__snapshots__/node.test.ts.snap
+++ b/test/projects/__snapshots__/node.test.ts.snap
@@ -737,7 +737,7 @@ jobs:
         with:
           token: \${{ secrets.PROJEN_GITHUB_TOKEN }}
           commit-message: |-
-            feat(deps): upgrade runtime dependencies
+            chore(deps): upgrade runtime dependencies
 
             Upgrades project dependencies. See details in [workflow run].
 
@@ -747,7 +747,7 @@ jobs:
 
             *Automatically created by projen via the \\"upgrade-runtime-dependencies-main\\" workflow*
           branch: github-actions/upgrade-runtime-dependencies-main
-          title: \\"feat(deps): upgrade runtime dependencies\\"
+          title: \\"chore(deps): upgrade runtime dependencies\\"
           labels: auto-approve
           body: |-
             Upgrades project dependencies. See details in [workflow run].
@@ -984,7 +984,7 @@ permissions-backup.acl
           "BUMPFILE": "dist/version.txt",
           "CHANGELOG": "dist/changelog.md",
           "OUTFILE": "package.json",
-          "RELEASABLE_COMMITS": "git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\\\\([^()[:space:]]+\\\\))?(!)?:[[:blank:]]+.+'",
+          "RELEASABLE_COMMITS": "git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\\\\([^()[:space:]]+\\\\))?(!)?:[[:blank:]]+.+' --grep 'chore\\\\(deps\\\\): upgrade runtime dependencies' --grep 'chore\\\\(deps\\\\): upgrade compiler dependencies'",
           "RELEASETAG": "dist/releasetag.txt",
           "RELEASE_TAG_PREFIX": "",
         },
@@ -1143,7 +1143,7 @@ permissions-backup.acl
           "BUMPFILE": "dist/version.txt",
           "CHANGELOG": "dist/changelog.md",
           "OUTFILE": "package.json",
-          "RELEASABLE_COMMITS": "git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\\\\([^()[:space:]]+\\\\))?(!)?:[[:blank:]]+.+'",
+          "RELEASABLE_COMMITS": "git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\\\\([^()[:space:]]+\\\\))?(!)?:[[:blank:]]+.+' --grep 'chore\\\\(deps\\\\): upgrade runtime dependencies' --grep 'chore\\\\(deps\\\\): upgrade compiler dependencies'",
           "RELEASETAG": "dist/releasetag.txt",
           "RELEASE_TAG_PREFIX": "",
         },
@@ -2198,7 +2198,7 @@ jobs:
         with:
           token: \${{ secrets.PROJEN_GITHUB_TOKEN }}
           commit-message: |-
-            feat(deps): upgrade runtime dependencies
+            chore(deps): upgrade runtime dependencies
 
             Upgrades project dependencies. See details in [workflow run].
 
@@ -2208,7 +2208,7 @@ jobs:
 
             *Automatically created by projen via the \\"upgrade-runtime-dependencies\\" workflow*
           branch: github-actions/upgrade-runtime-dependencies
-          title: \\"feat(deps): upgrade runtime dependencies\\"
+          title: \\"chore(deps): upgrade runtime dependencies\\"
           labels: auto-approve
           body: |-
             Upgrades project dependencies. See details in [workflow run].
@@ -3552,7 +3552,7 @@ jobs:
         with:
           token: \${{ secrets.PROJEN_GITHUB_TOKEN }}
           commit-message: |-
-            feat(deps): upgrade runtime dependencies
+            chore(deps): upgrade runtime dependencies
 
             Upgrades project dependencies. See details in [workflow run].
 
@@ -3562,7 +3562,7 @@ jobs:
 
             *Automatically created by projen via the \\"upgrade-runtime-dependencies\\" workflow*
           branch: github-actions/upgrade-runtime-dependencies
-          title: \\"feat(deps): upgrade runtime dependencies\\"
+          title: \\"chore(deps): upgrade runtime dependencies\\"
           labels: auto-approve
           body: |-
             Upgrades project dependencies. See details in [workflow run].
@@ -4906,7 +4906,7 @@ jobs:
         with:
           token: \${{ secrets.PROJEN_GITHUB_TOKEN }}
           commit-message: |-
-            feat(deps): upgrade runtime dependencies
+            chore(deps): upgrade runtime dependencies
 
             Upgrades project dependencies. See details in [workflow run].
 
@@ -4916,7 +4916,7 @@ jobs:
 
             *Automatically created by projen via the \\"upgrade-runtime-dependencies\\" workflow*
           branch: github-actions/upgrade-runtime-dependencies
-          title: \\"feat(deps): upgrade runtime dependencies\\"
+          title: \\"chore(deps): upgrade runtime dependencies\\"
           labels: auto-approve
           body: |-
             Upgrades project dependencies. See details in [workflow run].
@@ -6343,7 +6343,7 @@ jobs:
         with:
           token: \${{ secrets.PROJEN_GITHUB_TOKEN }}
           commit-message: |-
-            feat(deps): upgrade runtime dependencies
+            chore(deps): upgrade runtime dependencies
 
             Upgrades project dependencies. See details in [workflow run].
 
@@ -6353,7 +6353,7 @@ jobs:
 
             *Automatically created by projen via the \\"upgrade-runtime-dependencies-main\\" workflow*
           branch: github-actions/upgrade-runtime-dependencies-main
-          title: \\"feat(deps): upgrade runtime dependencies\\"
+          title: \\"chore(deps): upgrade runtime dependencies\\"
           labels: auto-approve
           body: |-
             Upgrades project dependencies. See details in [workflow run].
@@ -6562,7 +6562,7 @@ permissions-backup.acl
           "BUMPFILE": "dist/version.txt",
           "CHANGELOG": "dist/changelog.md",
           "OUTFILE": "package.json",
-          "RELEASABLE_COMMITS": "git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\\\\([^()[:space:]]+\\\\))?(!)?:[[:blank:]]+.+'",
+          "RELEASABLE_COMMITS": "git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\\\\([^()[:space:]]+\\\\))?(!)?:[[:blank:]]+.+' --grep 'chore\\\\(deps\\\\): upgrade runtime dependencies' --grep 'chore\\\\(deps\\\\): upgrade compiler dependencies'",
           "RELEASETAG": "dist/releasetag.txt",
           "RELEASE_TAG_PREFIX": "",
         },
@@ -6721,7 +6721,7 @@ permissions-backup.acl
           "BUMPFILE": "dist/version.txt",
           "CHANGELOG": "dist/changelog.md",
           "OUTFILE": "package.json",
-          "RELEASABLE_COMMITS": "git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\\\\([^()[:space:]]+\\\\))?(!)?:[[:blank:]]+.+'",
+          "RELEASABLE_COMMITS": "git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\\\\([^()[:space:]]+\\\\))?(!)?:[[:blank:]]+.+' --grep 'chore\\\\(deps\\\\): upgrade runtime dependencies' --grep 'chore\\\\(deps\\\\): upgrade compiler dependencies'",
           "RELEASETAG": "dist/releasetag.txt",
           "RELEASE_TAG_PREFIX": "",
         },
@@ -7854,7 +7854,7 @@ jobs:
         with:
           token: \${{ secrets.PROJEN_GITHUB_TOKEN }}
           commit-message: |-
-            feat(deps): upgrade runtime dependencies
+            chore(deps): upgrade runtime dependencies
 
             Upgrades project dependencies. See details in [workflow run].
 
@@ -7864,7 +7864,7 @@ jobs:
 
             *Automatically created by projen via the \\"upgrade-runtime-dependencies-main\\" workflow*
           branch: github-actions/upgrade-runtime-dependencies-main
-          title: \\"feat(deps): upgrade runtime dependencies\\"
+          title: \\"chore(deps): upgrade runtime dependencies\\"
           labels: auto-approve
           body: |-
             Upgrades project dependencies. See details in [workflow run].
@@ -8073,7 +8073,7 @@ permissions-backup.acl
           "BUMPFILE": "dist/version.txt",
           "CHANGELOG": "dist/changelog.md",
           "OUTFILE": "package.json",
-          "RELEASABLE_COMMITS": "git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\\\\([^()[:space:]]+\\\\))?(!)?:[[:blank:]]+.+'",
+          "RELEASABLE_COMMITS": "git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\\\\([^()[:space:]]+\\\\))?(!)?:[[:blank:]]+.+' --grep 'chore\\\\(deps\\\\): upgrade runtime dependencies' --grep 'chore\\\\(deps\\\\): upgrade compiler dependencies'",
           "RELEASETAG": "dist/releasetag.txt",
           "RELEASE_TAG_PREFIX": "",
         },
@@ -8232,7 +8232,7 @@ permissions-backup.acl
           "BUMPFILE": "dist/version.txt",
           "CHANGELOG": "dist/changelog.md",
           "OUTFILE": "package.json",
-          "RELEASABLE_COMMITS": "git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\\\\([^()[:space:]]+\\\\))?(!)?:[[:blank:]]+.+'",
+          "RELEASABLE_COMMITS": "git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\\\\([^()[:space:]]+\\\\))?(!)?:[[:blank:]]+.+' --grep 'chore\\\\(deps\\\\): upgrade runtime dependencies' --grep 'chore\\\\(deps\\\\): upgrade compiler dependencies'",
           "RELEASETAG": "dist/releasetag.txt",
           "RELEASE_TAG_PREFIX": "",
         },
@@ -9365,7 +9365,7 @@ jobs:
         with:
           token: \${{ secrets.PROJEN_GITHUB_TOKEN }}
           commit-message: |-
-            feat(deps): upgrade runtime dependencies
+            chore(deps): upgrade runtime dependencies
 
             Upgrades project dependencies. See details in [workflow run].
 
@@ -9375,7 +9375,7 @@ jobs:
 
             *Automatically created by projen via the \\"upgrade-runtime-dependencies-main\\" workflow*
           branch: github-actions/upgrade-runtime-dependencies-main
-          title: \\"feat(deps): upgrade runtime dependencies\\"
+          title: \\"chore(deps): upgrade runtime dependencies\\"
           labels: auto-approve
           body: |-
             Upgrades project dependencies. See details in [workflow run].
@@ -9584,7 +9584,7 @@ permissions-backup.acl
           "BUMPFILE": "dist/version.txt",
           "CHANGELOG": "dist/changelog.md",
           "OUTFILE": "package.json",
-          "RELEASABLE_COMMITS": "git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\\\\([^()[:space:]]+\\\\))?(!)?:[[:blank:]]+.+'",
+          "RELEASABLE_COMMITS": "git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\\\\([^()[:space:]]+\\\\))?(!)?:[[:blank:]]+.+' --grep 'chore\\\\(deps\\\\): upgrade runtime dependencies' --grep 'chore\\\\(deps\\\\): upgrade compiler dependencies'",
           "RELEASETAG": "dist/releasetag.txt",
           "RELEASE_TAG_PREFIX": "",
         },
@@ -9743,7 +9743,7 @@ permissions-backup.acl
           "BUMPFILE": "dist/version.txt",
           "CHANGELOG": "dist/changelog.md",
           "OUTFILE": "package.json",
-          "RELEASABLE_COMMITS": "git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\\\\([^()[:space:]]+\\\\))?(!)?:[[:blank:]]+.+'",
+          "RELEASABLE_COMMITS": "git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\\\\([^()[:space:]]+\\\\))?(!)?:[[:blank:]]+.+' --grep 'chore\\\\(deps\\\\): upgrade runtime dependencies' --grep 'chore\\\\(deps\\\\): upgrade compiler dependencies'",
           "RELEASETAG": "dist/releasetag.txt",
           "RELEASE_TAG_PREFIX": "",
         },
@@ -10876,7 +10876,7 @@ jobs:
         with:
           token: \${{ secrets.PROJEN_GITHUB_TOKEN }}
           commit-message: |-
-            feat(deps): upgrade runtime dependencies
+            chore(deps): upgrade runtime dependencies
 
             Upgrades project dependencies. See details in [workflow run].
 
@@ -10886,7 +10886,7 @@ jobs:
 
             *Automatically created by projen via the \\"upgrade-runtime-dependencies-main\\" workflow*
           branch: github-actions/upgrade-runtime-dependencies-main
-          title: \\"feat(deps): upgrade runtime dependencies\\"
+          title: \\"chore(deps): upgrade runtime dependencies\\"
           labels: auto-approve
           body: |-
             Upgrades project dependencies. See details in [workflow run].
@@ -11095,7 +11095,7 @@ permissions-backup.acl
           "BUMPFILE": "dist/version.txt",
           "CHANGELOG": "dist/changelog.md",
           "OUTFILE": "package.json",
-          "RELEASABLE_COMMITS": "git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\\\\([^()[:space:]]+\\\\))?(!)?:[[:blank:]]+.+'",
+          "RELEASABLE_COMMITS": "git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\\\\([^()[:space:]]+\\\\))?(!)?:[[:blank:]]+.+' --grep 'chore\\\\(deps\\\\): upgrade runtime dependencies' --grep 'chore\\\\(deps\\\\): upgrade compiler dependencies'",
           "RELEASETAG": "dist/releasetag.txt",
           "RELEASE_TAG_PREFIX": "",
         },
@@ -11254,7 +11254,7 @@ permissions-backup.acl
           "BUMPFILE": "dist/version.txt",
           "CHANGELOG": "dist/changelog.md",
           "OUTFILE": "package.json",
-          "RELEASABLE_COMMITS": "git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\\\\([^()[:space:]]+\\\\))?(!)?:[[:blank:]]+.+'",
+          "RELEASABLE_COMMITS": "git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\\\\([^()[:space:]]+\\\\))?(!)?:[[:blank:]]+.+' --grep 'chore\\\\(deps\\\\): upgrade runtime dependencies' --grep 'chore\\\\(deps\\\\): upgrade compiler dependencies'",
           "RELEASETAG": "dist/releasetag.txt",
           "RELEASE_TAG_PREFIX": "",
         },
@@ -12387,7 +12387,7 @@ jobs:
         with:
           token: \${{ secrets.PROJEN_GITHUB_TOKEN }}
           commit-message: |-
-            feat(deps): upgrade runtime dependencies
+            chore(deps): upgrade runtime dependencies
 
             Upgrades project dependencies. See details in [workflow run].
 
@@ -12397,7 +12397,7 @@ jobs:
 
             *Automatically created by projen via the \\"upgrade-runtime-dependencies-main\\" workflow*
           branch: github-actions/upgrade-runtime-dependencies-main
-          title: \\"feat(deps): upgrade runtime dependencies\\"
+          title: \\"chore(deps): upgrade runtime dependencies\\"
           labels: auto-approve
           body: |-
             Upgrades project dependencies. See details in [workflow run].
@@ -12606,7 +12606,7 @@ permissions-backup.acl
           "BUMPFILE": "dist/version.txt",
           "CHANGELOG": "dist/changelog.md",
           "OUTFILE": "package.json",
-          "RELEASABLE_COMMITS": "git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\\\\([^()[:space:]]+\\\\))?(!)?:[[:blank:]]+.+'",
+          "RELEASABLE_COMMITS": "git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\\\\([^()[:space:]]+\\\\))?(!)?:[[:blank:]]+.+' --grep 'chore\\\\(deps\\\\): upgrade runtime dependencies' --grep 'chore\\\\(deps\\\\): upgrade compiler dependencies'",
           "RELEASETAG": "dist/releasetag.txt",
           "RELEASE_TAG_PREFIX": "",
         },
@@ -12765,7 +12765,7 @@ permissions-backup.acl
           "BUMPFILE": "dist/version.txt",
           "CHANGELOG": "dist/changelog.md",
           "OUTFILE": "package.json",
-          "RELEASABLE_COMMITS": "git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\\\\([^()[:space:]]+\\\\))?(!)?:[[:blank:]]+.+'",
+          "RELEASABLE_COMMITS": "git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\\\\([^()[:space:]]+\\\\))?(!)?:[[:blank:]]+.+' --grep 'chore\\\\(deps\\\\): upgrade runtime dependencies' --grep 'chore\\\\(deps\\\\): upgrade compiler dependencies'",
           "RELEASETAG": "dist/releasetag.txt",
           "RELEASE_TAG_PREFIX": "",
         },

--- a/test/projects/__snapshots__/typescript.test.ts.snap
+++ b/test/projects/__snapshots__/typescript.test.ts.snap
@@ -737,7 +737,7 @@ jobs:
         with:
           token: \${{ secrets.PROJEN_GITHUB_TOKEN }}
           commit-message: |-
-            feat(deps): upgrade compiler dependencies
+            chore(deps): upgrade compiler dependencies
 
             Upgrades project dependencies. See details in [workflow run].
 
@@ -747,7 +747,7 @@ jobs:
 
             *Automatically created by projen via the \\"upgrade-compiler-dependencies-main\\" workflow*
           branch: github-actions/upgrade-compiler-dependencies-main
-          title: \\"feat(deps): upgrade compiler dependencies\\"
+          title: \\"chore(deps): upgrade compiler dependencies\\"
           labels: auto-approve
           body: |-
             Upgrades project dependencies. See details in [workflow run].
@@ -1013,7 +1013,7 @@ jobs:
         with:
           token: \${{ secrets.PROJEN_GITHUB_TOKEN }}
           commit-message: |-
-            feat(deps): upgrade runtime dependencies
+            chore(deps): upgrade runtime dependencies
 
             Upgrades project dependencies. See details in [workflow run].
 
@@ -1023,7 +1023,7 @@ jobs:
 
             *Automatically created by projen via the \\"upgrade-runtime-dependencies-main\\" workflow*
           branch: github-actions/upgrade-runtime-dependencies-main
-          title: \\"feat(deps): upgrade runtime dependencies\\"
+          title: \\"chore(deps): upgrade runtime dependencies\\"
           labels: auto-approve
           body: |-
             Upgrades project dependencies. See details in [workflow run].
@@ -1301,7 +1301,7 @@ tsconfig.tsbuildinfo
           "BUMPFILE": "dist/version.txt",
           "CHANGELOG": "dist/changelog.md",
           "OUTFILE": "package.json",
-          "RELEASABLE_COMMITS": "git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\\\\([^()[:space:]]+\\\\))?(!)?:[[:blank:]]+.+'",
+          "RELEASABLE_COMMITS": "git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\\\\([^()[:space:]]+\\\\))?(!)?:[[:blank:]]+.+' --grep 'chore\\\\(deps\\\\): upgrade runtime dependencies' --grep 'chore\\\\(deps\\\\): upgrade compiler dependencies'",
           "RELEASETAG": "dist/releasetag.txt",
           "RELEASE_TAG_PREFIX": "",
         },
@@ -1477,7 +1477,7 @@ tsconfig.tsbuildinfo
           "BUMPFILE": "dist/version.txt",
           "CHANGELOG": "dist/changelog.md",
           "OUTFILE": "package.json",
-          "RELEASABLE_COMMITS": "git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\\\\([^()[:space:]]+\\\\))?(!)?:[[:blank:]]+.+'",
+          "RELEASABLE_COMMITS": "git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\\\\([^()[:space:]]+\\\\))?(!)?:[[:blank:]]+.+' --grep 'chore\\\\(deps\\\\): upgrade runtime dependencies' --grep 'chore\\\\(deps\\\\): upgrade compiler dependencies'",
           "RELEASETAG": "dist/releasetag.txt",
           "RELEASE_TAG_PREFIX": "",
         },
@@ -2846,7 +2846,7 @@ jobs:
         with:
           token: \${{ secrets.PROJEN_GITHUB_TOKEN }}
           commit-message: |-
-            feat(deps): upgrade compiler dependencies
+            chore(deps): upgrade compiler dependencies
 
             Upgrades project dependencies. See details in [workflow run].
 
@@ -2856,7 +2856,7 @@ jobs:
 
             *Automatically created by projen via the \\"upgrade-compiler-dependencies-main\\" workflow*
           branch: github-actions/upgrade-compiler-dependencies-main
-          title: \\"feat(deps): upgrade compiler dependencies\\"
+          title: \\"chore(deps): upgrade compiler dependencies\\"
           labels: auto-approve
           body: |-
             Upgrades project dependencies. See details in [workflow run].
@@ -3122,7 +3122,7 @@ jobs:
         with:
           token: \${{ secrets.PROJEN_GITHUB_TOKEN }}
           commit-message: |-
-            feat(deps): upgrade runtime dependencies
+            chore(deps): upgrade runtime dependencies
 
             Upgrades project dependencies. See details in [workflow run].
 
@@ -3132,7 +3132,7 @@ jobs:
 
             *Automatically created by projen via the \\"upgrade-runtime-dependencies-main\\" workflow*
           branch: github-actions/upgrade-runtime-dependencies-main
-          title: \\"feat(deps): upgrade runtime dependencies\\"
+          title: \\"chore(deps): upgrade runtime dependencies\\"
           labels: auto-approve
           body: |-
             Upgrades project dependencies. See details in [workflow run].
@@ -3438,7 +3438,7 @@ tsconfig.tsbuildinfo
           "BUMPFILE": "dist/version.txt",
           "CHANGELOG": "dist/changelog.md",
           "OUTFILE": "package.json",
-          "RELEASABLE_COMMITS": "git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\\\\([^()[:space:]]+\\\\))?(!)?:[[:blank:]]+.+'",
+          "RELEASABLE_COMMITS": "git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\\\\([^()[:space:]]+\\\\))?(!)?:[[:blank:]]+.+' --grep 'chore\\\\(deps\\\\): upgrade runtime dependencies' --grep 'chore\\\\(deps\\\\): upgrade compiler dependencies'",
           "RELEASETAG": "dist/releasetag.txt",
           "RELEASE_TAG_PREFIX": "",
         },
@@ -3614,7 +3614,7 @@ tsconfig.tsbuildinfo
           "BUMPFILE": "dist/version.txt",
           "CHANGELOG": "dist/changelog.md",
           "OUTFILE": "package.json",
-          "RELEASABLE_COMMITS": "git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\\\\([^()[:space:]]+\\\\))?(!)?:[[:blank:]]+.+'",
+          "RELEASABLE_COMMITS": "git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\\\\([^()[:space:]]+\\\\))?(!)?:[[:blank:]]+.+' --grep 'chore\\\\(deps\\\\): upgrade runtime dependencies' --grep 'chore\\\\(deps\\\\): upgrade compiler dependencies'",
           "RELEASETAG": "dist/releasetag.txt",
           "RELEASE_TAG_PREFIX": "",
         },
@@ -4860,7 +4860,7 @@ jobs:
         with:
           token: \${{ secrets.PROJEN_GITHUB_TOKEN }}
           commit-message: |-
-            feat(deps): upgrade compiler dependencies
+            chore(deps): upgrade compiler dependencies
 
             Upgrades project dependencies. See details in [workflow run].
 
@@ -4870,7 +4870,7 @@ jobs:
 
             *Automatically created by projen via the \\"upgrade-compiler-dependencies\\" workflow*
           branch: github-actions/upgrade-compiler-dependencies
-          title: \\"feat(deps): upgrade compiler dependencies\\"
+          title: \\"chore(deps): upgrade compiler dependencies\\"
           labels: auto-approve
           body: |-
             Upgrades project dependencies. See details in [workflow run].
@@ -5127,7 +5127,7 @@ jobs:
         with:
           token: \${{ secrets.PROJEN_GITHUB_TOKEN }}
           commit-message: |-
-            feat(deps): upgrade runtime dependencies
+            chore(deps): upgrade runtime dependencies
 
             Upgrades project dependencies. See details in [workflow run].
 
@@ -5137,7 +5137,7 @@ jobs:
 
             *Automatically created by projen via the \\"upgrade-runtime-dependencies\\" workflow*
           branch: github-actions/upgrade-runtime-dependencies
-          title: \\"feat(deps): upgrade runtime dependencies\\"
+          title: \\"chore(deps): upgrade runtime dependencies\\"
           labels: auto-approve
           body: |-
             Upgrades project dependencies. See details in [workflow run].
@@ -6758,7 +6758,7 @@ jobs:
         with:
           token: \${{ secrets.PROJEN_GITHUB_TOKEN }}
           commit-message: |-
-            feat(deps): upgrade compiler dependencies
+            chore(deps): upgrade compiler dependencies
 
             Upgrades project dependencies. See details in [workflow run].
 
@@ -6768,7 +6768,7 @@ jobs:
 
             *Automatically created by projen via the \\"upgrade-compiler-dependencies\\" workflow*
           branch: github-actions/upgrade-compiler-dependencies
-          title: \\"feat(deps): upgrade compiler dependencies\\"
+          title: \\"chore(deps): upgrade compiler dependencies\\"
           labels: auto-approve
           body: |-
             Upgrades project dependencies. See details in [workflow run].
@@ -7025,7 +7025,7 @@ jobs:
         with:
           token: \${{ secrets.PROJEN_GITHUB_TOKEN }}
           commit-message: |-
-            feat(deps): upgrade runtime dependencies
+            chore(deps): upgrade runtime dependencies
 
             Upgrades project dependencies. See details in [workflow run].
 
@@ -7035,7 +7035,7 @@ jobs:
 
             *Automatically created by projen via the \\"upgrade-runtime-dependencies\\" workflow*
           branch: github-actions/upgrade-runtime-dependencies
-          title: \\"feat(deps): upgrade runtime dependencies\\"
+          title: \\"chore(deps): upgrade runtime dependencies\\"
           labels: auto-approve
           body: |-
             Upgrades project dependencies. See details in [workflow run].
@@ -8656,7 +8656,7 @@ jobs:
         with:
           token: \${{ secrets.PROJEN_GITHUB_TOKEN }}
           commit-message: |-
-            feat(deps): upgrade compiler dependencies
+            chore(deps): upgrade compiler dependencies
 
             Upgrades project dependencies. See details in [workflow run].
 
@@ -8666,7 +8666,7 @@ jobs:
 
             *Automatically created by projen via the \\"upgrade-compiler-dependencies\\" workflow*
           branch: github-actions/upgrade-compiler-dependencies
-          title: \\"feat(deps): upgrade compiler dependencies\\"
+          title: \\"chore(deps): upgrade compiler dependencies\\"
           labels: auto-approve
           body: |-
             Upgrades project dependencies. See details in [workflow run].
@@ -8923,7 +8923,7 @@ jobs:
         with:
           token: \${{ secrets.PROJEN_GITHUB_TOKEN }}
           commit-message: |-
-            feat(deps): upgrade runtime dependencies
+            chore(deps): upgrade runtime dependencies
 
             Upgrades project dependencies. See details in [workflow run].
 
@@ -8933,7 +8933,7 @@ jobs:
 
             *Automatically created by projen via the \\"upgrade-runtime-dependencies\\" workflow*
           branch: github-actions/upgrade-runtime-dependencies
-          title: \\"feat(deps): upgrade runtime dependencies\\"
+          title: \\"chore(deps): upgrade runtime dependencies\\"
           labels: auto-approve
           body: |-
             Upgrades project dependencies. See details in [workflow run].
@@ -10631,7 +10631,7 @@ jobs:
         with:
           token: \${{ secrets.PROJEN_GITHUB_TOKEN }}
           commit-message: |-
-            feat(deps): upgrade compiler dependencies
+            chore(deps): upgrade compiler dependencies
 
             Upgrades project dependencies. See details in [workflow run].
 
@@ -10641,7 +10641,7 @@ jobs:
 
             *Automatically created by projen via the \\"upgrade-compiler-dependencies-main\\" workflow*
           branch: github-actions/upgrade-compiler-dependencies-main
-          title: \\"feat(deps): upgrade compiler dependencies\\"
+          title: \\"chore(deps): upgrade compiler dependencies\\"
           labels: auto-approve
           body: |-
             Upgrades project dependencies. See details in [workflow run].
@@ -10907,7 +10907,7 @@ jobs:
         with:
           token: \${{ secrets.PROJEN_GITHUB_TOKEN }}
           commit-message: |-
-            feat(deps): upgrade runtime dependencies
+            chore(deps): upgrade runtime dependencies
 
             Upgrades project dependencies. See details in [workflow run].
 
@@ -10917,7 +10917,7 @@ jobs:
 
             *Automatically created by projen via the \\"upgrade-runtime-dependencies-main\\" workflow*
           branch: github-actions/upgrade-runtime-dependencies-main
-          title: \\"feat(deps): upgrade runtime dependencies\\"
+          title: \\"chore(deps): upgrade runtime dependencies\\"
           labels: auto-approve
           body: |-
             Upgrades project dependencies. See details in [workflow run].
@@ -11195,7 +11195,7 @@ tsconfig.tsbuildinfo
           "BUMPFILE": "dist/version.txt",
           "CHANGELOG": "dist/changelog.md",
           "OUTFILE": "package.json",
-          "RELEASABLE_COMMITS": "git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\\\\([^()[:space:]]+\\\\))?(!)?:[[:blank:]]+.+'",
+          "RELEASABLE_COMMITS": "git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\\\\([^()[:space:]]+\\\\))?(!)?:[[:blank:]]+.+' --grep 'chore\\\\(deps\\\\): upgrade runtime dependencies' --grep 'chore\\\\(deps\\\\): upgrade compiler dependencies'",
           "RELEASETAG": "dist/releasetag.txt",
           "RELEASE_TAG_PREFIX": "",
         },
@@ -11371,7 +11371,7 @@ tsconfig.tsbuildinfo
           "BUMPFILE": "dist/version.txt",
           "CHANGELOG": "dist/changelog.md",
           "OUTFILE": "package.json",
-          "RELEASABLE_COMMITS": "git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\\\\([^()[:space:]]+\\\\))?(!)?:[[:blank:]]+.+'",
+          "RELEASABLE_COMMITS": "git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\\\\([^()[:space:]]+\\\\))?(!)?:[[:blank:]]+.+' --grep 'chore\\\\(deps\\\\): upgrade runtime dependencies' --grep 'chore\\\\(deps\\\\): upgrade compiler dependencies'",
           "RELEASETAG": "dist/releasetag.txt",
           "RELEASE_TAG_PREFIX": "",
         },
@@ -12689,7 +12689,7 @@ jobs:
         with:
           token: \${{ secrets.PROJEN_GITHUB_TOKEN }}
           commit-message: |-
-            feat(deps): upgrade compiler dependencies
+            chore(deps): upgrade compiler dependencies
 
             Upgrades project dependencies. See details in [workflow run].
 
@@ -12699,7 +12699,7 @@ jobs:
 
             *Automatically created by projen via the \\"upgrade-compiler-dependencies-main\\" workflow*
           branch: github-actions/upgrade-compiler-dependencies-main
-          title: \\"feat(deps): upgrade compiler dependencies\\"
+          title: \\"chore(deps): upgrade compiler dependencies\\"
           labels: auto-approve
           body: |-
             Upgrades project dependencies. See details in [workflow run].
@@ -12965,7 +12965,7 @@ jobs:
         with:
           token: \${{ secrets.PROJEN_GITHUB_TOKEN }}
           commit-message: |-
-            feat(deps): upgrade runtime dependencies
+            chore(deps): upgrade runtime dependencies
 
             Upgrades project dependencies. See details in [workflow run].
 
@@ -12975,7 +12975,7 @@ jobs:
 
             *Automatically created by projen via the \\"upgrade-runtime-dependencies-main\\" workflow*
           branch: github-actions/upgrade-runtime-dependencies-main
-          title: \\"feat(deps): upgrade runtime dependencies\\"
+          title: \\"chore(deps): upgrade runtime dependencies\\"
           labels: auto-approve
           body: |-
             Upgrades project dependencies. See details in [workflow run].
@@ -13253,7 +13253,7 @@ tsconfig.tsbuildinfo
           "BUMPFILE": "dist/version.txt",
           "CHANGELOG": "dist/changelog.md",
           "OUTFILE": "package.json",
-          "RELEASABLE_COMMITS": "git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\\\\([^()[:space:]]+\\\\))?(!)?:[[:blank:]]+.+'",
+          "RELEASABLE_COMMITS": "git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\\\\([^()[:space:]]+\\\\))?(!)?:[[:blank:]]+.+' --grep 'chore\\\\(deps\\\\): upgrade runtime dependencies' --grep 'chore\\\\(deps\\\\): upgrade compiler dependencies'",
           "RELEASETAG": "dist/releasetag.txt",
           "RELEASE_TAG_PREFIX": "",
         },
@@ -13429,7 +13429,7 @@ tsconfig.tsbuildinfo
           "BUMPFILE": "dist/version.txt",
           "CHANGELOG": "dist/changelog.md",
           "OUTFILE": "package.json",
-          "RELEASABLE_COMMITS": "git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\\\\([^()[:space:]]+\\\\))?(!)?:[[:blank:]]+.+'",
+          "RELEASABLE_COMMITS": "git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\\\\([^()[:space:]]+\\\\))?(!)?:[[:blank:]]+.+' --grep 'chore\\\\(deps\\\\): upgrade runtime dependencies' --grep 'chore\\\\(deps\\\\): upgrade compiler dependencies'",
           "RELEASETAG": "dist/releasetag.txt",
           "RELEASE_TAG_PREFIX": "",
         },
@@ -14747,7 +14747,7 @@ jobs:
         with:
           token: \${{ secrets.PROJEN_GITHUB_TOKEN }}
           commit-message: |-
-            feat(deps): upgrade compiler dependencies
+            chore(deps): upgrade compiler dependencies
 
             Upgrades project dependencies. See details in [workflow run].
 
@@ -14757,7 +14757,7 @@ jobs:
 
             *Automatically created by projen via the \\"upgrade-compiler-dependencies-main\\" workflow*
           branch: github-actions/upgrade-compiler-dependencies-main
-          title: \\"feat(deps): upgrade compiler dependencies\\"
+          title: \\"chore(deps): upgrade compiler dependencies\\"
           labels: auto-approve
           body: |-
             Upgrades project dependencies. See details in [workflow run].
@@ -15023,7 +15023,7 @@ jobs:
         with:
           token: \${{ secrets.PROJEN_GITHUB_TOKEN }}
           commit-message: |-
-            feat(deps): upgrade runtime dependencies
+            chore(deps): upgrade runtime dependencies
 
             Upgrades project dependencies. See details in [workflow run].
 
@@ -15033,7 +15033,7 @@ jobs:
 
             *Automatically created by projen via the \\"upgrade-runtime-dependencies-main\\" workflow*
           branch: github-actions/upgrade-runtime-dependencies-main
-          title: \\"feat(deps): upgrade runtime dependencies\\"
+          title: \\"chore(deps): upgrade runtime dependencies\\"
           labels: auto-approve
           body: |-
             Upgrades project dependencies. See details in [workflow run].
@@ -15311,7 +15311,7 @@ tsconfig.tsbuildinfo
           "BUMPFILE": "dist/version.txt",
           "CHANGELOG": "dist/changelog.md",
           "OUTFILE": "package.json",
-          "RELEASABLE_COMMITS": "git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\\\\([^()[:space:]]+\\\\))?(!)?:[[:blank:]]+.+'",
+          "RELEASABLE_COMMITS": "git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\\\\([^()[:space:]]+\\\\))?(!)?:[[:blank:]]+.+' --grep 'chore\\\\(deps\\\\): upgrade runtime dependencies' --grep 'chore\\\\(deps\\\\): upgrade compiler dependencies'",
           "RELEASETAG": "dist/releasetag.txt",
           "RELEASE_TAG_PREFIX": "",
         },
@@ -15487,7 +15487,7 @@ tsconfig.tsbuildinfo
           "BUMPFILE": "dist/version.txt",
           "CHANGELOG": "dist/changelog.md",
           "OUTFILE": "package.json",
-          "RELEASABLE_COMMITS": "git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\\\\([^()[:space:]]+\\\\))?(!)?:[[:blank:]]+.+'",
+          "RELEASABLE_COMMITS": "git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\\\\([^()[:space:]]+\\\\))?(!)?:[[:blank:]]+.+' --grep 'chore\\\\(deps\\\\): upgrade runtime dependencies' --grep 'chore\\\\(deps\\\\): upgrade compiler dependencies'",
           "RELEASETAG": "dist/releasetag.txt",
           "RELEASE_TAG_PREFIX": "",
         },
@@ -16805,7 +16805,7 @@ jobs:
         with:
           token: \${{ secrets.PROJEN_GITHUB_TOKEN }}
           commit-message: |-
-            feat(deps): upgrade compiler dependencies
+            chore(deps): upgrade compiler dependencies
 
             Upgrades project dependencies. See details in [workflow run].
 
@@ -16815,7 +16815,7 @@ jobs:
 
             *Automatically created by projen via the \\"upgrade-compiler-dependencies-main\\" workflow*
           branch: github-actions/upgrade-compiler-dependencies-main
-          title: \\"feat(deps): upgrade compiler dependencies\\"
+          title: \\"chore(deps): upgrade compiler dependencies\\"
           labels: auto-approve
           body: |-
             Upgrades project dependencies. See details in [workflow run].
@@ -17081,7 +17081,7 @@ jobs:
         with:
           token: \${{ secrets.PROJEN_GITHUB_TOKEN }}
           commit-message: |-
-            feat(deps): upgrade runtime dependencies
+            chore(deps): upgrade runtime dependencies
 
             Upgrades project dependencies. See details in [workflow run].
 
@@ -17091,7 +17091,7 @@ jobs:
 
             *Automatically created by projen via the \\"upgrade-runtime-dependencies-main\\" workflow*
           branch: github-actions/upgrade-runtime-dependencies-main
-          title: \\"feat(deps): upgrade runtime dependencies\\"
+          title: \\"chore(deps): upgrade runtime dependencies\\"
           labels: auto-approve
           body: |-
             Upgrades project dependencies. See details in [workflow run].
@@ -17369,7 +17369,7 @@ tsconfig.tsbuildinfo
           "BUMPFILE": "dist/version.txt",
           "CHANGELOG": "dist/changelog.md",
           "OUTFILE": "package.json",
-          "RELEASABLE_COMMITS": "git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\\\\([^()[:space:]]+\\\\))?(!)?:[[:blank:]]+.+'",
+          "RELEASABLE_COMMITS": "git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\\\\([^()[:space:]]+\\\\))?(!)?:[[:blank:]]+.+' --grep 'chore\\\\(deps\\\\): upgrade runtime dependencies' --grep 'chore\\\\(deps\\\\): upgrade compiler dependencies'",
           "RELEASETAG": "dist/releasetag.txt",
           "RELEASE_TAG_PREFIX": "",
         },
@@ -17545,7 +17545,7 @@ tsconfig.tsbuildinfo
           "BUMPFILE": "dist/version.txt",
           "CHANGELOG": "dist/changelog.md",
           "OUTFILE": "package.json",
-          "RELEASABLE_COMMITS": "git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\\\\([^()[:space:]]+\\\\))?(!)?:[[:blank:]]+.+'",
+          "RELEASABLE_COMMITS": "git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\\\\([^()[:space:]]+\\\\))?(!)?:[[:blank:]]+.+' --grep 'chore\\\\(deps\\\\): upgrade runtime dependencies' --grep 'chore\\\\(deps\\\\): upgrade compiler dependencies'",
           "RELEASETAG": "dist/releasetag.txt",
           "RELEASE_TAG_PREFIX": "",
         },
@@ -18863,7 +18863,7 @@ jobs:
         with:
           token: \${{ secrets.PROJEN_GITHUB_TOKEN }}
           commit-message: |-
-            feat(deps): upgrade compiler dependencies
+            chore(deps): upgrade compiler dependencies
 
             Upgrades project dependencies. See details in [workflow run].
 
@@ -18873,7 +18873,7 @@ jobs:
 
             *Automatically created by projen via the \\"upgrade-compiler-dependencies-main\\" workflow*
           branch: github-actions/upgrade-compiler-dependencies-main
-          title: \\"feat(deps): upgrade compiler dependencies\\"
+          title: \\"chore(deps): upgrade compiler dependencies\\"
           labels: auto-approve
           body: |-
             Upgrades project dependencies. See details in [workflow run].
@@ -19139,7 +19139,7 @@ jobs:
         with:
           token: \${{ secrets.PROJEN_GITHUB_TOKEN }}
           commit-message: |-
-            feat(deps): upgrade runtime dependencies
+            chore(deps): upgrade runtime dependencies
 
             Upgrades project dependencies. See details in [workflow run].
 
@@ -19149,7 +19149,7 @@ jobs:
 
             *Automatically created by projen via the \\"upgrade-runtime-dependencies-main\\" workflow*
           branch: github-actions/upgrade-runtime-dependencies-main
-          title: \\"feat(deps): upgrade runtime dependencies\\"
+          title: \\"chore(deps): upgrade runtime dependencies\\"
           labels: auto-approve
           body: |-
             Upgrades project dependencies. See details in [workflow run].
@@ -19427,7 +19427,7 @@ tsconfig.tsbuildinfo
           "BUMPFILE": "dist/version.txt",
           "CHANGELOG": "dist/changelog.md",
           "OUTFILE": "package.json",
-          "RELEASABLE_COMMITS": "git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\\\\([^()[:space:]]+\\\\))?(!)?:[[:blank:]]+.+'",
+          "RELEASABLE_COMMITS": "git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\\\\([^()[:space:]]+\\\\))?(!)?:[[:blank:]]+.+' --grep 'chore\\\\(deps\\\\): upgrade runtime dependencies' --grep 'chore\\\\(deps\\\\): upgrade compiler dependencies'",
           "RELEASETAG": "dist/releasetag.txt",
           "RELEASE_TAG_PREFIX": "",
         },
@@ -19603,7 +19603,7 @@ tsconfig.tsbuildinfo
           "BUMPFILE": "dist/version.txt",
           "CHANGELOG": "dist/changelog.md",
           "OUTFILE": "package.json",
-          "RELEASABLE_COMMITS": "git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\\\\([^()[:space:]]+\\\\))?(!)?:[[:blank:]]+.+'",
+          "RELEASABLE_COMMITS": "git log --no-merges --oneline $LATEST_TAG..HEAD -E --grep '^(feat|fix){1}(\\\\([^()[:space:]]+\\\\))?(!)?:[[:blank:]]+.+' --grep 'chore\\\\(deps\\\\): upgrade runtime dependencies' --grep 'chore\\\\(deps\\\\): upgrade compiler dependencies'",
           "RELEASETAG": "dist/releasetag.txt",
           "RELEASE_TAG_PREFIX": "",
         },


### PR DESCRIPTION
This is rather unintuitive, as these releases don't have any added functionality to them. Using patch is more appropriate, it is also what we used before splitting the dependency upgrade workflows. 