### PR TITLE
fix: `downlevel-dts` package causes daily identical releases

### DIFF
--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -111,6 +111,11 @@
       "type": "override"
     },
     {
+      "name": "**/downlevel-dts/**/typescript",
+      "version": "~5.2.2",
+      "type": "override"
+    },
+    {
       "name": "projen",
       "type": "peer"
     },

--- a/package.json
+++ b/package.json
@@ -71,7 +71,8 @@
   ],
   "resolutions": {
     "@types/babel__traverse": "7.18.2",
-    "@types/prettier": "2.6.0"
+    "@types/prettier": "2.6.0",
+    "**/downlevel-dts/**/typescript": "~5.2.2"
   },
   "main": "lib/index.js",
   "license": "Apache-2.0",

--- a/src/projects/jsii.ts
+++ b/src/projects/jsii.ts
@@ -107,6 +107,10 @@ export class Cdk8sTeamJsiiProject extends cdk.JsiiProject {
     if (options.backport ?? false) {
       new Backport(this, { branches: options.backportBranches, repoName });
     }
+
+    // prevent upgrading the typescript version used by downlevel-dts because
+    // it depends on typescript@next - which causes daily identical releases.
+    this.package.addPackageResolutions('**/downlevel-dts/**/typescript@~5.2.2');
   }
 }
 

--- a/test/projects/__snapshots__/jsii.test.ts.snap
+++ b/test/projects/__snapshots__/jsii.test.ts.snap
@@ -1600,6 +1600,11 @@ tsconfig.tsbuildinfo
         "type": "override",
         "version": "2.6.0",
       },
+      Object {
+        "name": "**/downlevel-dts/**/typescript",
+        "type": "override",
+        "version": "~5.2.2",
+      },
     ],
   },
   ".projen/files.json": Object {
@@ -2447,6 +2452,7 @@ echo \\"Configured core.hooksPath to \${hooksdir}\\"
       "url": "https://github.com/cdk8s-team/root.git",
     },
     "resolutions": Object {
+      "**/downlevel-dts/**/typescript": "~5.2.2",
       "@types/babel__traverse": "7.18.2",
       "@types/prettier": "2.6.0",
     },
@@ -4186,6 +4192,11 @@ tsconfig.tsbuildinfo
         "type": "override",
         "version": "2.6.0",
       },
+      Object {
+        "name": "**/downlevel-dts/**/typescript",
+        "type": "override",
+        "version": "~5.2.2",
+      },
     ],
   },
   ".projen/files.json": Object {
@@ -5062,6 +5073,7 @@ echo \\"Configured core.hooksPath to \${hooksdir}\\"
       "url": "https://github.com/cdk8s-team/root.git",
     },
     "resolutions": Object {
+      "**/downlevel-dts/**/typescript": "~5.2.2",
       "@types/babel__traverse": "7.18.2",
       "@types/prettier": "2.6.0",
     },
@@ -6316,6 +6328,11 @@ tsconfig.tsbuildinfo
         "type": "override",
         "version": "2.6.0",
       },
+      Object {
+        "name": "**/downlevel-dts/**/typescript",
+        "type": "override",
+        "version": "~5.2.2",
+      },
     ],
   },
   ".projen/files.json": Object {
@@ -7021,6 +7038,7 @@ echo \\"Configured core.hooksPath to \${hooksdir}\\"
       "url": "https://github.com/cdk8s-team/custom-repo-name.git",
     },
     "resolutions": Object {
+      "**/downlevel-dts/**/typescript": "~5.2.2",
       "@types/babel__traverse": "7.18.2",
       "@types/prettier": "2.6.0",
     },
@@ -8394,6 +8412,11 @@ tsconfig.tsbuildinfo
         "type": "override",
         "version": "2.6.0",
       },
+      Object {
+        "name": "**/downlevel-dts/**/typescript",
+        "type": "override",
+        "version": "~5.2.2",
+      },
     ],
   },
   ".projen/files.json": Object {
@@ -9168,6 +9191,7 @@ echo \\"Configured core.hooksPath to \${hooksdir}\\"
       "url": "https://github.com/cdk8s-team/custom-repo-name.git",
     },
     "resolutions": Object {
+      "**/downlevel-dts/**/typescript": "~5.2.2",
       "@types/babel__traverse": "7.18.2",
       "@types/prettier": "2.6.0",
     },
@@ -10416,6 +10440,11 @@ tsconfig.tsbuildinfo
         "type": "override",
         "version": "2.6.0",
       },
+      Object {
+        "name": "**/downlevel-dts/**/typescript",
+        "type": "override",
+        "version": "~5.2.2",
+      },
     ],
   },
   ".projen/files.json": Object {
@@ -11121,6 +11150,7 @@ echo \\"Configured core.hooksPath to \${hooksdir}\\"
       "url": "https://github.com/cdk8s-team/custom-repo-name.git",
     },
     "resolutions": Object {
+      "**/downlevel-dts/**/typescript": "~5.2.2",
       "@types/babel__traverse": "7.18.2",
       "@types/prettier": "2.6.0",
     },
@@ -12494,6 +12524,11 @@ tsconfig.tsbuildinfo
         "type": "override",
         "version": "2.6.0",
       },
+      Object {
+        "name": "**/downlevel-dts/**/typescript",
+        "type": "override",
+        "version": "~5.2.2",
+      },
     ],
   },
   ".projen/files.json": Object {
@@ -13268,6 +13303,7 @@ echo \\"Configured core.hooksPath to \${hooksdir}\\"
       "url": "https://github.com/cdk8s-team/custom-repo-name.git",
     },
     "resolutions": Object {
+      "**/downlevel-dts/**/typescript": "~5.2.2",
       "@types/babel__traverse": "7.18.2",
       "@types/prettier": "2.6.0",
     },
@@ -14516,6 +14552,11 @@ tsconfig.tsbuildinfo
         "type": "override",
         "version": "2.6.0",
       },
+      Object {
+        "name": "**/downlevel-dts/**/typescript",
+        "type": "override",
+        "version": "~5.2.2",
+      },
     ],
   },
   ".projen/files.json": Object {
@@ -15221,6 +15262,7 @@ echo \\"Configured core.hooksPath to \${hooksdir}\\"
       "url": "https://github.com/cdk8s-team/custom-repo-name.git",
     },
     "resolutions": Object {
+      "**/downlevel-dts/**/typescript": "~5.2.2",
       "@types/babel__traverse": "7.18.2",
       "@types/prettier": "2.6.0",
     },
@@ -16594,6 +16636,11 @@ tsconfig.tsbuildinfo
         "type": "override",
         "version": "2.6.0",
       },
+      Object {
+        "name": "**/downlevel-dts/**/typescript",
+        "type": "override",
+        "version": "~5.2.2",
+      },
     ],
   },
   ".projen/files.json": Object {
@@ -17368,6 +17415,7 @@ echo \\"Configured core.hooksPath to \${hooksdir}\\"
       "url": "https://github.com/cdk8s-team/custom-repo-name.git",
     },
     "resolutions": Object {
+      "**/downlevel-dts/**/typescript": "~5.2.2",
       "@types/babel__traverse": "7.18.2",
       "@types/prettier": "2.6.0",
     },
@@ -19050,6 +19098,11 @@ tsconfig.tsbuildinfo
         "type": "override",
         "version": "2.6.0",
       },
+      Object {
+        "name": "**/downlevel-dts/**/typescript",
+        "type": "override",
+        "version": "~5.2.2",
+      },
     ],
   },
   ".projen/files.json": Object {
@@ -19897,6 +19950,7 @@ echo \\"Configured core.hooksPath to \${hooksdir}\\"
       "url": "https://github.com/cdk8s-team/cdk8s-sample.git",
     },
     "resolutions": Object {
+      "**/downlevel-dts/**/typescript": "~5.2.2",
       "@types/babel__traverse": "7.18.2",
       "@types/prettier": "2.6.0",
     },
@@ -21583,6 +21637,11 @@ tsconfig.tsbuildinfo
         "type": "override",
         "version": "2.6.0",
       },
+      Object {
+        "name": "**/downlevel-dts/**/typescript",
+        "type": "override",
+        "version": "~5.2.2",
+      },
     ],
   },
   ".projen/files.json": Object {
@@ -22430,6 +22489,7 @@ echo \\"Configured core.hooksPath to \${hooksdir}\\"
       "url": "https://github.com/cdk8s-team/root.git",
     },
     "resolutions": Object {
+      "**/downlevel-dts/**/typescript": "~5.2.2",
       "@types/babel__traverse": "7.18.2",
       "@types/prettier": "2.6.0",
     },
@@ -24116,6 +24176,11 @@ tsconfig.tsbuildinfo
         "type": "override",
         "version": "2.6.0",
       },
+      Object {
+        "name": "**/downlevel-dts/**/typescript",
+        "type": "override",
+        "version": "~5.2.2",
+      },
     ],
   },
   ".projen/files.json": Object {
@@ -24963,6 +25028,7 @@ echo \\"Configured core.hooksPath to \${hooksdir}\\"
       "url": "https://github.com/cdk8s-team/cdk8s-sample.git",
     },
     "resolutions": Object {
+      "**/downlevel-dts/**/typescript": "~5.2.2",
       "@types/babel__traverse": "7.18.2",
       "@types/prettier": "2.6.0",
     },
@@ -26649,6 +26715,11 @@ tsconfig.tsbuildinfo
         "type": "override",
         "version": "2.6.0",
       },
+      Object {
+        "name": "**/downlevel-dts/**/typescript",
+        "type": "override",
+        "version": "~5.2.2",
+      },
     ],
   },
   ".projen/files.json": Object {
@@ -27496,6 +27567,7 @@ echo \\"Configured core.hooksPath to \${hooksdir}\\"
       "url": "https://github.com/cdk8s-team/cdk8s.git",
     },
     "resolutions": Object {
+      "**/downlevel-dts/**/typescript": "~5.2.2",
       "@types/babel__traverse": "7.18.2",
       "@types/prettier": "2.6.0",
     },
@@ -29182,6 +29254,11 @@ tsconfig.tsbuildinfo
         "type": "override",
         "version": "2.6.0",
       },
+      Object {
+        "name": "**/downlevel-dts/**/typescript",
+        "type": "override",
+        "version": "~5.2.2",
+      },
     ],
   },
   ".projen/files.json": Object {
@@ -30029,6 +30106,7 @@ echo \\"Configured core.hooksPath to \${hooksdir}\\"
       "url": "https://github.com/cdk8s-team/root.git",
     },
     "resolutions": Object {
+      "**/downlevel-dts/**/typescript": "~5.2.2",
       "@types/babel__traverse": "7.18.2",
       "@types/prettier": "2.6.0",
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -6206,6 +6206,11 @@ typescript@~3.9.10:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.10.tgz#70f3910ac7a51ed6bef79da7800690b19bf778b8"
   integrity sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==
 
+typescript@~5.2.2:
+  version "5.2.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.2.2.tgz#5ebb5e5a5b75f085f22bc3f8460fba308310fa78"
+  integrity sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==
+
 uglify-js@^3.1.4:
   version "3.17.4"
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.17.4.tgz#61678cf5fa3f5b7eb789bb345df29afb8257c22c"


### PR DESCRIPTION
There's no real need to bump the typescript version used by downlevel-dts. Its also unclear why they depend on a nightly unstable typescript, and we are better off operating on the stable typescript version. 

Not that all of this matters anyway because we don't emit downleveled types anyway (because we dont need to), and its unlikely we ever will.