### PR TITLE
feat: update workflowNodeVersion to 18.17.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files
       - name: build
@@ -91,7 +91,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: release
@@ -55,7 +55,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -84,7 +84,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/upgrade-compiler-dependencies-main.yml
+++ b/.github/workflows/upgrade-compiler-dependencies-main.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies

--- a/.github/workflows/upgrade-dev-dependencies-main.yml
+++ b/.github/workflows/upgrade-dev-dependencies-main.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies

--- a/.github/workflows/upgrade-runtime-dependencies-main.yml
+++ b/.github/workflows/upgrade-runtime-dependencies-main.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies

--- a/src/projects/node.ts
+++ b/src/projects/node.ts
@@ -97,6 +97,7 @@ export function buildNodeProjectDefaultOptions(options: Cdk8sTeamNodeProjectOpti
     // if release is enabled, default to releasing to npm as well
     releaseToNpm: options.release,
     minNodeVersion: '16.20.0',
+    workflowNodeVersion: '18.17.0',
     depsUpgradeOptions,
   };
 }

--- a/test/projects/__snapshots__/jsii.test.ts.snap
+++ b/test/projects/__snapshots__/jsii.test.ts.snap
@@ -432,7 +432,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files
       - name: build
@@ -501,7 +501,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -530,7 +530,7 @@ jobs:
           java-version: 11.x
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -555,7 +555,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - uses: actions/setup-python@v4
         with:
           python-version: 3.x
@@ -583,7 +583,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - uses: actions/setup-dotnet@v3
         with:
           dotnet-version: 3.x
@@ -611,7 +611,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - uses: actions/setup-go@v3
         with:
           go-version: ^1.16.0
@@ -691,7 +691,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: release
@@ -719,7 +719,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -748,7 +748,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -785,7 +785,7 @@ jobs:
           java-version: 11.x
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -820,7 +820,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - uses: actions/setup-python@v4
         with:
           python-version: 3.x
@@ -855,7 +855,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - uses: actions/setup-dotnet@v3
         with:
           dotnet-version: 3.x
@@ -889,7 +889,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - uses: actions/setup-go@v3
         with:
           go-version: ^1.16.0
@@ -1019,7 +1019,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -1203,7 +1203,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -1295,7 +1295,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -2984,7 +2984,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Set Git Identity
@@ -3020,7 +3020,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files
       - name: build
@@ -3089,7 +3089,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -3118,7 +3118,7 @@ jobs:
           java-version: 11.x
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -3143,7 +3143,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - uses: actions/setup-python@v4
         with:
           python-version: 3.x
@@ -3171,7 +3171,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - uses: actions/setup-dotnet@v3
         with:
           dotnet-version: 3.x
@@ -3199,7 +3199,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - uses: actions/setup-go@v3
         with:
           go-version: ^1.16.0
@@ -3279,7 +3279,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: release
@@ -3307,7 +3307,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -3336,7 +3336,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -3373,7 +3373,7 @@ jobs:
           java-version: 11.x
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -3408,7 +3408,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - uses: actions/setup-python@v4
         with:
           python-version: 3.x
@@ -3443,7 +3443,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - uses: actions/setup-dotnet@v3
         with:
           dotnet-version: 3.x
@@ -3477,7 +3477,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - uses: actions/setup-go@v3
         with:
           go-version: ^1.16.0
@@ -3607,7 +3607,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -3791,7 +3791,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -3883,7 +3883,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -5589,7 +5589,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files
       - name: build
@@ -5773,7 +5773,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -5951,7 +5951,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -6040,7 +6040,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -7542,7 +7542,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files
       - name: build
@@ -7615,7 +7615,7 @@ jobs:
           java-version: 11.x
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -7640,7 +7640,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - uses: actions/setup-python@v4
         with:
           python-version: 3.x
@@ -7668,7 +7668,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - uses: actions/setup-dotnet@v3
         with:
           dotnet-version: 3.x
@@ -7696,7 +7696,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - uses: actions/setup-go@v3
         with:
           go-version: ^1.16.0
@@ -7847,7 +7847,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -8025,7 +8025,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -8114,7 +8114,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -9697,7 +9697,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files
       - name: build
@@ -9881,7 +9881,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -10059,7 +10059,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -10148,7 +10148,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -11650,7 +11650,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files
       - name: build
@@ -11723,7 +11723,7 @@ jobs:
           java-version: 11.x
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -11748,7 +11748,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - uses: actions/setup-python@v4
         with:
           python-version: 3.x
@@ -11776,7 +11776,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - uses: actions/setup-dotnet@v3
         with:
           dotnet-version: 3.x
@@ -11804,7 +11804,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - uses: actions/setup-go@v3
         with:
           go-version: ^1.16.0
@@ -11955,7 +11955,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -12133,7 +12133,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -12222,7 +12222,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -13805,7 +13805,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files
       - name: build
@@ -13989,7 +13989,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -14167,7 +14167,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -14256,7 +14256,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -15758,7 +15758,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files
       - name: build
@@ -15831,7 +15831,7 @@ jobs:
           java-version: 11.x
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -15856,7 +15856,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - uses: actions/setup-python@v4
         with:
           python-version: 3.x
@@ -15884,7 +15884,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - uses: actions/setup-dotnet@v3
         with:
           dotnet-version: 3.x
@@ -15912,7 +15912,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - uses: actions/setup-go@v3
         with:
           go-version: ^1.16.0
@@ -16063,7 +16063,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -16241,7 +16241,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -16330,7 +16330,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -17914,7 +17914,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files
       - name: build
@@ -17983,7 +17983,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -18012,7 +18012,7 @@ jobs:
           java-version: 11.x
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -18037,7 +18037,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - uses: actions/setup-python@v4
         with:
           python-version: 3.x
@@ -18065,7 +18065,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - uses: actions/setup-dotnet@v3
         with:
           dotnet-version: 3.x
@@ -18093,7 +18093,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - uses: actions/setup-go@v3
         with:
           go-version: ^1.16.0
@@ -18173,7 +18173,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: release
@@ -18201,7 +18201,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -18230,7 +18230,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -18267,7 +18267,7 @@ jobs:
           java-version: 11.x
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -18302,7 +18302,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - uses: actions/setup-python@v4
         with:
           python-version: 3.x
@@ -18337,7 +18337,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - uses: actions/setup-dotnet@v3
         with:
           dotnet-version: 3.x
@@ -18371,7 +18371,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - uses: actions/setup-go@v3
         with:
           go-version: ^1.16.0
@@ -18501,7 +18501,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -18685,7 +18685,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -18777,7 +18777,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -20451,7 +20451,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files
       - name: build
@@ -20520,7 +20520,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -20549,7 +20549,7 @@ jobs:
           java-version: 11.x
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -20574,7 +20574,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - uses: actions/setup-python@v4
         with:
           python-version: 3.x
@@ -20602,7 +20602,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - uses: actions/setup-dotnet@v3
         with:
           dotnet-version: 3.x
@@ -20630,7 +20630,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - uses: actions/setup-go@v3
         with:
           go-version: ^1.16.0
@@ -20710,7 +20710,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: release
@@ -20738,7 +20738,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -20767,7 +20767,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -20804,7 +20804,7 @@ jobs:
           java-version: 11.x
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -20839,7 +20839,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - uses: actions/setup-python@v4
         with:
           python-version: 3.x
@@ -20874,7 +20874,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - uses: actions/setup-dotnet@v3
         with:
           dotnet-version: 3.x
@@ -20908,7 +20908,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - uses: actions/setup-go@v3
         with:
           go-version: ^1.16.0
@@ -21038,7 +21038,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -21222,7 +21222,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -21314,7 +21314,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -22988,7 +22988,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files
       - name: build
@@ -23057,7 +23057,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -23086,7 +23086,7 @@ jobs:
           java-version: 11.x
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -23111,7 +23111,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - uses: actions/setup-python@v4
         with:
           python-version: 3.x
@@ -23139,7 +23139,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - uses: actions/setup-dotnet@v3
         with:
           dotnet-version: 3.x
@@ -23167,7 +23167,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - uses: actions/setup-go@v3
         with:
           go-version: ^1.16.0
@@ -23247,7 +23247,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: release
@@ -23275,7 +23275,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -23304,7 +23304,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -23341,7 +23341,7 @@ jobs:
           java-version: 11.x
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -23376,7 +23376,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - uses: actions/setup-python@v4
         with:
           python-version: 3.x
@@ -23411,7 +23411,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - uses: actions/setup-dotnet@v3
         with:
           dotnet-version: 3.x
@@ -23445,7 +23445,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - uses: actions/setup-go@v3
         with:
           go-version: ^1.16.0
@@ -23575,7 +23575,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -23759,7 +23759,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -23851,7 +23851,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -25525,7 +25525,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files
       - name: build
@@ -25594,7 +25594,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -25623,7 +25623,7 @@ jobs:
           java-version: 11.x
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -25648,7 +25648,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - uses: actions/setup-python@v4
         with:
           python-version: 3.x
@@ -25676,7 +25676,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - uses: actions/setup-dotnet@v3
         with:
           dotnet-version: 3.x
@@ -25704,7 +25704,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - uses: actions/setup-go@v3
         with:
           go-version: ^1.16.0
@@ -25784,7 +25784,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: release
@@ -25812,7 +25812,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -25841,7 +25841,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -25878,7 +25878,7 @@ jobs:
           java-version: 11.x
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -25913,7 +25913,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - uses: actions/setup-python@v4
         with:
           python-version: 3.x
@@ -25948,7 +25948,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - uses: actions/setup-dotnet@v3
         with:
           dotnet-version: 3.x
@@ -25982,7 +25982,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - uses: actions/setup-go@v3
         with:
           go-version: ^1.16.0
@@ -26112,7 +26112,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -26296,7 +26296,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -26388,7 +26388,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -28062,7 +28062,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files
       - name: build
@@ -28131,7 +28131,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -28160,7 +28160,7 @@ jobs:
           java-version: 11.x
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -28185,7 +28185,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - uses: actions/setup-python@v4
         with:
           python-version: 3.x
@@ -28213,7 +28213,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - uses: actions/setup-dotnet@v3
         with:
           dotnet-version: 3.x
@@ -28241,7 +28241,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - uses: actions/setup-go@v3
         with:
           go-version: ^1.16.0
@@ -28321,7 +28321,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: release
@@ -28349,7 +28349,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -28378,7 +28378,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -28415,7 +28415,7 @@ jobs:
           java-version: 11.x
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -28450,7 +28450,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - uses: actions/setup-python@v4
         with:
           python-version: 3.x
@@ -28485,7 +28485,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - uses: actions/setup-dotnet@v3
         with:
           dotnet-version: 3.x
@@ -28519,7 +28519,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - uses: actions/setup-go@v3
         with:
           go-version: ^1.16.0
@@ -28649,7 +28649,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -28833,7 +28833,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -28925,7 +28925,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies

--- a/test/projects/__snapshots__/node.test.ts.snap
+++ b/test/projects/__snapshots__/node.test.ts.snap
@@ -212,7 +212,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Set Git Identity
@@ -248,7 +248,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files
       - name: build
@@ -361,7 +361,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: release
@@ -389,7 +389,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -599,7 +599,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -691,7 +691,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -1794,7 +1794,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 14.18.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files
       - name: build
@@ -2067,7 +2067,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 14.18.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -2156,7 +2156,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 14.18.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -3151,7 +3151,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files
       - name: build
@@ -3424,7 +3424,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -3513,7 +3513,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -4508,7 +4508,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files
       - name: build
@@ -4781,7 +4781,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -4870,7 +4870,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -5866,7 +5866,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files
       - name: build
@@ -5979,7 +5979,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: release
@@ -6007,7 +6007,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -6217,7 +6217,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -6309,7 +6309,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -7380,7 +7380,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files
       - name: build
@@ -7493,7 +7493,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: release
@@ -7521,7 +7521,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -7731,7 +7731,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -7823,7 +7823,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -8894,7 +8894,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files
       - name: build
@@ -9007,7 +9007,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: release
@@ -9035,7 +9035,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -9245,7 +9245,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -9337,7 +9337,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -10408,7 +10408,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files
       - name: build
@@ -10521,7 +10521,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: release
@@ -10549,7 +10549,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -10759,7 +10759,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -10851,7 +10851,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -11922,7 +11922,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files
       - name: build
@@ -12035,7 +12035,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: release
@@ -12063,7 +12063,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -12273,7 +12273,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -12365,7 +12365,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies

--- a/test/projects/__snapshots__/typescript.test.ts.snap
+++ b/test/projects/__snapshots__/typescript.test.ts.snap
@@ -432,7 +432,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files
       - name: build
@@ -545,7 +545,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: release
@@ -573,7 +573,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -691,7 +691,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -875,7 +875,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -967,7 +967,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -2503,7 +2503,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Set Git Identity
@@ -2539,7 +2539,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files
       - name: build
@@ -2652,7 +2652,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: release
@@ -2680,7 +2680,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -2798,7 +2798,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -2982,7 +2982,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -3074,7 +3074,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -4627,7 +4627,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files
       - name: build
@@ -4811,7 +4811,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -4989,7 +4989,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -5078,7 +5078,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -6523,7 +6523,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files
       - name: build
@@ -6707,7 +6707,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -6885,7 +6885,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -6974,7 +6974,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -8419,7 +8419,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files
       - name: build
@@ -8603,7 +8603,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -8781,7 +8781,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -8870,7 +8870,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -10316,7 +10316,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files
       - name: build
@@ -10429,7 +10429,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: release
@@ -10457,7 +10457,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -10575,7 +10575,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -10759,7 +10759,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -10851,7 +10851,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -12372,7 +12372,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files
       - name: build
@@ -12485,7 +12485,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: release
@@ -12513,7 +12513,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -12631,7 +12631,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -12815,7 +12815,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -12907,7 +12907,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -14428,7 +14428,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files
       - name: build
@@ -14541,7 +14541,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: release
@@ -14569,7 +14569,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -14687,7 +14687,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -14871,7 +14871,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -14963,7 +14963,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -16484,7 +16484,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files
       - name: build
@@ -16597,7 +16597,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: release
@@ -16625,7 +16625,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -16743,7 +16743,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -16927,7 +16927,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -17019,7 +17019,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -18540,7 +18540,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files
       - name: build
@@ -18653,7 +18653,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: release
@@ -18681,7 +18681,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -18799,7 +18799,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -18983,7 +18983,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -19075,7 +19075,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.20.0
+          node-version: 18.17.0
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies


### PR DESCRIPTION
Updating workflowNodeVersion to `18.17.0` to unblock builds in PRs. This version is LTS: https://nodejs.org/en/blog/release/v18.17.0