### PR TITLE
fix: isolated peer upgrades break upgrade workflows

### DIFF
--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -341,13 +341,13 @@
       },
       "steps": [
         {
-          "exec": "npx npm-check-updates@16 --upgrade --target=minor --peer --dep=peer,prod,optional --filter=projen,codemaker"
+          "exec": "npx npm-check-updates@16 --upgrade --target=minor --peer --dep=prod,optional --filter=codemaker"
         },
         {
           "exec": "yarn install --check-files"
         },
         {
-          "exec": "yarn upgrade projen codemaker"
+          "exec": "yarn upgrade codemaker"
         },
         {
           "exec": "npx projen"

--- a/src/projects/node.ts
+++ b/src/projects/node.ts
@@ -86,8 +86,12 @@ export function buildNodeProjectDefaultOptions(options: Cdk8sTeamNodeProjectOpti
   const depsUpgradeOptions: UpgradeDependenciesOptions = {
     taskName: 'upgrade-runtime-dependencies',
     pullRequestTitle: 'upgrade runtime dependencies',
-    // only include peer and runtime because we will created a non release trigerring PR for the rest
-    types: [DependencyType.PEER, DependencyType.RUNTIME, DependencyType.OPTIONAL],
+    // only include plain dependency because we will created a non release triggering PR for the rest
+    // NOTE: we explicitly do NOT upgrade PEER dependencies. We want the widest range of compatibility possible,
+    // and by bumping peer dependencies we force the customer to also unnecessarily upgrade, which they may not want
+    // to do. Never mind that peerDependencies are usually also devDependencies, so it doesn't make sense to upgrade
+    // them without also upgrading devDependencies.
+    types: [DependencyType.RUNTIME, DependencyType.OPTIONAL],
     workflowOptions: {
       schedule: UpgradeDependenciesSchedule.expressions([UPGRADE_RUNTIME_DEPENDENCIES_SCHEDULE]),
     },


### PR DESCRIPTION
As for example seen in: https://github.com/cdk8s-team/cdk8s-hasura/pull/407

The workflow upgrades the peer dependency:

```
cdk8s-plus-27: ^2.7.61 -> ^2.7.66
```

But leaves the devDependency unchanged:

```
cdk8s-plus-27: 2.7.61
```

And then the install fails because its requirements are not satisfied.

Instead, don't upgrade peer dependencies automtically. If we need to do a peerDependency upgrade, we will do it by hand.

Fixes #