### PR TITLE
chore: update workflowNodeVersion to lts/*

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files
       - name: build
@@ -91,7 +91,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: release
@@ -55,7 +55,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -84,7 +84,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/upgrade-compiler-dependencies-main.yml
+++ b/.github/workflows/upgrade-compiler-dependencies-main.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies

--- a/.github/workflows/upgrade-dev-dependencies-main.yml
+++ b/.github/workflows/upgrade-dev-dependencies-main.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies

--- a/.github/workflows/upgrade-runtime-dependencies-main.yml
+++ b/.github/workflows/upgrade-runtime-dependencies-main.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies

--- a/src/projects/node.ts
+++ b/src/projects/node.ts
@@ -101,7 +101,7 @@ export function buildNodeProjectDefaultOptions(options: Cdk8sTeamNodeProjectOpti
     // if release is enabled, default to releasing to npm as well
     releaseToNpm: options.release,
     minNodeVersion: '16.20.0',
-    workflowNodeVersion: '18.17.0',
+    workflowNodeVersion: 'lts/*',
     depsUpgradeOptions,
   };
 }
@@ -236,7 +236,7 @@ export function addComponents(project: NodeProject, repoName: string, branches?:
     configDeps.push('@cdk8s/projen-common');
   }
 
-  const configUpgrade = new UpgradeDependencies(project, {
+  new UpgradeDependencies(project, {
     include: configDeps,
     taskName: 'upgrade-configuration',
     pullRequestTitle: 'upgrade configuration',
@@ -246,7 +246,6 @@ export function addComponents(project: NodeProject, repoName: string, branches?:
       schedule: UpgradeDependenciesSchedule.expressions([UPGRADE_CONFIGURATION_SCHEDULE]),
     },
   });
-  configUpgrade.workflows.forEach(wf => wf.file?.addOverride('jobs.upgrade.steps.1.with.node-version', 'lts/*'));
 
   new UpgradeDependencies(project, {
     exclude: [...configDeps, ...(compilerDeps ?? [])],

--- a/test/projects/__snapshots__/jsii.test.ts.snap
+++ b/test/projects/__snapshots__/jsii.test.ts.snap
@@ -432,7 +432,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files
       - name: build
@@ -501,7 +501,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -530,7 +530,7 @@ jobs:
           java-version: 11.x
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -555,7 +555,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - uses: actions/setup-python@v4
         with:
           python-version: 3.x
@@ -583,7 +583,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - uses: actions/setup-dotnet@v3
         with:
           dotnet-version: 3.x
@@ -611,7 +611,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - uses: actions/setup-go@v3
         with:
           go-version: ^1.16.0
@@ -691,7 +691,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: release
@@ -719,7 +719,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -748,7 +748,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -785,7 +785,7 @@ jobs:
           java-version: 11.x
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -820,7 +820,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - uses: actions/setup-python@v4
         with:
           python-version: 3.x
@@ -855,7 +855,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - uses: actions/setup-dotnet@v3
         with:
           dotnet-version: 3.x
@@ -889,7 +889,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - uses: actions/setup-go@v3
         with:
           go-version: ^1.16.0
@@ -1019,7 +1019,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -1203,7 +1203,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -1295,7 +1295,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -2969,7 +2969,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Set Git Identity
@@ -3005,7 +3005,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files
       - name: build
@@ -3074,7 +3074,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -3103,7 +3103,7 @@ jobs:
           java-version: 11.x
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -3128,7 +3128,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - uses: actions/setup-python@v4
         with:
           python-version: 3.x
@@ -3156,7 +3156,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - uses: actions/setup-dotnet@v3
         with:
           dotnet-version: 3.x
@@ -3184,7 +3184,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - uses: actions/setup-go@v3
         with:
           go-version: ^1.16.0
@@ -3264,7 +3264,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: release
@@ -3292,7 +3292,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -3321,7 +3321,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -3358,7 +3358,7 @@ jobs:
           java-version: 11.x
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -3393,7 +3393,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - uses: actions/setup-python@v4
         with:
           python-version: 3.x
@@ -3428,7 +3428,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - uses: actions/setup-dotnet@v3
         with:
           dotnet-version: 3.x
@@ -3462,7 +3462,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - uses: actions/setup-go@v3
         with:
           go-version: ^1.16.0
@@ -3592,7 +3592,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -3776,7 +3776,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -3868,7 +3868,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -5559,7 +5559,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files
       - name: build
@@ -5743,7 +5743,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -5921,7 +5921,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -6010,7 +6010,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -7497,7 +7497,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files
       - name: build
@@ -7570,7 +7570,7 @@ jobs:
           java-version: 11.x
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -7595,7 +7595,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - uses: actions/setup-python@v4
         with:
           python-version: 3.x
@@ -7623,7 +7623,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - uses: actions/setup-dotnet@v3
         with:
           dotnet-version: 3.x
@@ -7651,7 +7651,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - uses: actions/setup-go@v3
         with:
           go-version: ^1.16.0
@@ -7802,7 +7802,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -7980,7 +7980,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -8069,7 +8069,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -9637,7 +9637,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files
       - name: build
@@ -9821,7 +9821,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -9999,7 +9999,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -10088,7 +10088,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -11575,7 +11575,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files
       - name: build
@@ -11648,7 +11648,7 @@ jobs:
           java-version: 11.x
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -11673,7 +11673,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - uses: actions/setup-python@v4
         with:
           python-version: 3.x
@@ -11701,7 +11701,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - uses: actions/setup-dotnet@v3
         with:
           dotnet-version: 3.x
@@ -11729,7 +11729,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - uses: actions/setup-go@v3
         with:
           go-version: ^1.16.0
@@ -11880,7 +11880,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -12058,7 +12058,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -12147,7 +12147,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -13715,7 +13715,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files
       - name: build
@@ -13899,7 +13899,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -14077,7 +14077,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -14166,7 +14166,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -15653,7 +15653,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files
       - name: build
@@ -15726,7 +15726,7 @@ jobs:
           java-version: 11.x
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -15751,7 +15751,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - uses: actions/setup-python@v4
         with:
           python-version: 3.x
@@ -15779,7 +15779,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - uses: actions/setup-dotnet@v3
         with:
           dotnet-version: 3.x
@@ -15807,7 +15807,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - uses: actions/setup-go@v3
         with:
           go-version: ^1.16.0
@@ -15958,7 +15958,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -16136,7 +16136,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -16225,7 +16225,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -17794,7 +17794,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files
       - name: build
@@ -17863,7 +17863,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -17892,7 +17892,7 @@ jobs:
           java-version: 11.x
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -17917,7 +17917,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - uses: actions/setup-python@v4
         with:
           python-version: 3.x
@@ -17945,7 +17945,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - uses: actions/setup-dotnet@v3
         with:
           dotnet-version: 3.x
@@ -17973,7 +17973,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - uses: actions/setup-go@v3
         with:
           go-version: ^1.16.0
@@ -18053,7 +18053,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: release
@@ -18081,7 +18081,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -18110,7 +18110,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -18147,7 +18147,7 @@ jobs:
           java-version: 11.x
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -18182,7 +18182,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - uses: actions/setup-python@v4
         with:
           python-version: 3.x
@@ -18217,7 +18217,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - uses: actions/setup-dotnet@v3
         with:
           dotnet-version: 3.x
@@ -18251,7 +18251,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - uses: actions/setup-go@v3
         with:
           go-version: ^1.16.0
@@ -18381,7 +18381,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -18565,7 +18565,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -18657,7 +18657,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -20316,7 +20316,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files
       - name: build
@@ -20385,7 +20385,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -20414,7 +20414,7 @@ jobs:
           java-version: 11.x
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -20439,7 +20439,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - uses: actions/setup-python@v4
         with:
           python-version: 3.x
@@ -20467,7 +20467,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - uses: actions/setup-dotnet@v3
         with:
           dotnet-version: 3.x
@@ -20495,7 +20495,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - uses: actions/setup-go@v3
         with:
           go-version: ^1.16.0
@@ -20575,7 +20575,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: release
@@ -20603,7 +20603,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -20632,7 +20632,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -20669,7 +20669,7 @@ jobs:
           java-version: 11.x
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -20704,7 +20704,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - uses: actions/setup-python@v4
         with:
           python-version: 3.x
@@ -20739,7 +20739,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - uses: actions/setup-dotnet@v3
         with:
           dotnet-version: 3.x
@@ -20773,7 +20773,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - uses: actions/setup-go@v3
         with:
           go-version: ^1.16.0
@@ -20903,7 +20903,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -21087,7 +21087,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -21179,7 +21179,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -22838,7 +22838,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files
       - name: build
@@ -22907,7 +22907,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -22936,7 +22936,7 @@ jobs:
           java-version: 11.x
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -22961,7 +22961,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - uses: actions/setup-python@v4
         with:
           python-version: 3.x
@@ -22989,7 +22989,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - uses: actions/setup-dotnet@v3
         with:
           dotnet-version: 3.x
@@ -23017,7 +23017,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - uses: actions/setup-go@v3
         with:
           go-version: ^1.16.0
@@ -23097,7 +23097,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: release
@@ -23125,7 +23125,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -23154,7 +23154,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -23191,7 +23191,7 @@ jobs:
           java-version: 11.x
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -23226,7 +23226,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - uses: actions/setup-python@v4
         with:
           python-version: 3.x
@@ -23261,7 +23261,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - uses: actions/setup-dotnet@v3
         with:
           dotnet-version: 3.x
@@ -23295,7 +23295,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - uses: actions/setup-go@v3
         with:
           go-version: ^1.16.0
@@ -23425,7 +23425,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -23609,7 +23609,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -23701,7 +23701,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -25360,7 +25360,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files
       - name: build
@@ -25429,7 +25429,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -25458,7 +25458,7 @@ jobs:
           java-version: 11.x
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -25483,7 +25483,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - uses: actions/setup-python@v4
         with:
           python-version: 3.x
@@ -25511,7 +25511,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - uses: actions/setup-dotnet@v3
         with:
           dotnet-version: 3.x
@@ -25539,7 +25539,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - uses: actions/setup-go@v3
         with:
           go-version: ^1.16.0
@@ -25619,7 +25619,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: release
@@ -25647,7 +25647,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -25676,7 +25676,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -25713,7 +25713,7 @@ jobs:
           java-version: 11.x
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -25748,7 +25748,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - uses: actions/setup-python@v4
         with:
           python-version: 3.x
@@ -25783,7 +25783,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - uses: actions/setup-dotnet@v3
         with:
           dotnet-version: 3.x
@@ -25817,7 +25817,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - uses: actions/setup-go@v3
         with:
           go-version: ^1.16.0
@@ -25947,7 +25947,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -26131,7 +26131,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -26223,7 +26223,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -27882,7 +27882,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files
       - name: build
@@ -27951,7 +27951,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -27980,7 +27980,7 @@ jobs:
           java-version: 11.x
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -28005,7 +28005,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - uses: actions/setup-python@v4
         with:
           python-version: 3.x
@@ -28033,7 +28033,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - uses: actions/setup-dotnet@v3
         with:
           dotnet-version: 3.x
@@ -28061,7 +28061,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - uses: actions/setup-go@v3
         with:
           go-version: ^1.16.0
@@ -28141,7 +28141,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: release
@@ -28169,7 +28169,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -28198,7 +28198,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -28235,7 +28235,7 @@ jobs:
           java-version: 11.x
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -28270,7 +28270,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - uses: actions/setup-python@v4
         with:
           python-version: 3.x
@@ -28305,7 +28305,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - uses: actions/setup-dotnet@v3
         with:
           dotnet-version: 3.x
@@ -28339,7 +28339,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - uses: actions/setup-go@v3
         with:
           go-version: ^1.16.0
@@ -28469,7 +28469,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -28653,7 +28653,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -28745,7 +28745,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies

--- a/test/projects/__snapshots__/node.test.ts.snap
+++ b/test/projects/__snapshots__/node.test.ts.snap
@@ -212,7 +212,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Set Git Identity
@@ -248,7 +248,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files
       - name: build
@@ -361,7 +361,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: release
@@ -389,7 +389,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -599,7 +599,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -691,7 +691,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -1782,7 +1782,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files
       - name: build
@@ -2055,7 +2055,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -2144,7 +2144,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -3127,7 +3127,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files
       - name: build
@@ -3400,7 +3400,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -3489,7 +3489,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -4472,7 +4472,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files
       - name: build
@@ -4745,7 +4745,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -4834,7 +4834,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -5818,7 +5818,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files
       - name: build
@@ -5931,7 +5931,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: release
@@ -5959,7 +5959,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -6169,7 +6169,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -6261,7 +6261,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -7320,7 +7320,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files
       - name: build
@@ -7433,7 +7433,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: release
@@ -7461,7 +7461,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -7671,7 +7671,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -7763,7 +7763,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -8822,7 +8822,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files
       - name: build
@@ -8935,7 +8935,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: release
@@ -8963,7 +8963,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -9173,7 +9173,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -9265,7 +9265,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -10324,7 +10324,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files
       - name: build
@@ -10437,7 +10437,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: release
@@ -10465,7 +10465,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -10675,7 +10675,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -10767,7 +10767,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -11826,7 +11826,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files
       - name: build
@@ -11939,7 +11939,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: release
@@ -11967,7 +11967,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -12177,7 +12177,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -12269,7 +12269,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies

--- a/test/projects/__snapshots__/typescript.test.ts.snap
+++ b/test/projects/__snapshots__/typescript.test.ts.snap
@@ -432,7 +432,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files
       - name: build
@@ -545,7 +545,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: release
@@ -573,7 +573,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -691,7 +691,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -875,7 +875,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -967,7 +967,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -2488,7 +2488,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Set Git Identity
@@ -2524,7 +2524,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files
       - name: build
@@ -2637,7 +2637,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: release
@@ -2665,7 +2665,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -2783,7 +2783,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -2967,7 +2967,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -3059,7 +3059,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -4597,7 +4597,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files
       - name: build
@@ -4781,7 +4781,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -4959,7 +4959,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -5048,7 +5048,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -6478,7 +6478,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files
       - name: build
@@ -6662,7 +6662,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -6840,7 +6840,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -6929,7 +6929,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -8359,7 +8359,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files
       - name: build
@@ -8543,7 +8543,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -8721,7 +8721,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -8810,7 +8810,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -10241,7 +10241,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files
       - name: build
@@ -10354,7 +10354,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: release
@@ -10382,7 +10382,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -10500,7 +10500,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -10684,7 +10684,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -10776,7 +10776,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -12282,7 +12282,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files
       - name: build
@@ -12395,7 +12395,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: release
@@ -12423,7 +12423,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -12541,7 +12541,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -12725,7 +12725,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -12817,7 +12817,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -14323,7 +14323,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files
       - name: build
@@ -14436,7 +14436,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: release
@@ -14464,7 +14464,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -14582,7 +14582,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -14766,7 +14766,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -14858,7 +14858,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -16364,7 +16364,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files
       - name: build
@@ -16477,7 +16477,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: release
@@ -16505,7 +16505,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -16623,7 +16623,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -16807,7 +16807,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -16899,7 +16899,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -18405,7 +18405,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files
       - name: build
@@ -18518,7 +18518,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: release
@@ -18546,7 +18546,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Download build artifacts
         uses: actions/download-artifact@v3
         with:
@@ -18664,7 +18664,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -18848,7 +18848,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies
@@ -18940,7 +18940,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18.17.0
+          node-version: lts/*
       - name: Install dependencies
         run: yarn install --check-files --frozen-lockfile
       - name: Upgrade dependencies


### PR DESCRIPTION
Currently `upgrade-configuration` workflows are failing for `cdk8s-cli`: https://github.com/cdk8s-team/cdk8s-cli/actions/runs/6998871953.

This is due to us editing the workflow file and adding `lts/*` based on step number. This step number changes if we have `workflow bootstrap steps`, which would [precede](https://github.com/projen/projen/blob/da981a3e2651344ef2cc342708e67c75c0433c02/src/javascript/node-project.ts#L974C9-L974C9) node step. This results in us editing the file at the incorrect spot and lead to an incorrect workflow yaml file. 

Instead of editing the workflow file and relying on the step number to be correct, I am instead adding this to `workflowNodeVersion` property of projen projects.