### PR TITLE
fix: minimum workflow Node to 18.12

### DIFF
--- a/src/projects/node.ts
+++ b/src/projects/node.ts
@@ -31,6 +31,7 @@ export const fixedOptionsKeys = [
   'autoApproveOptions',
   'autoApproveUpgrades',
   'releasableCommits',
+  'workflowNodeVersion',
 
   // this is deprecated in favor of 'release'.
   // lets disallow using it.
@@ -75,6 +76,9 @@ export function buildNodeProjectFixedOptions(options: Cdk8sTeamNodeProjectOption
     autoApproveUpgrades: true,
     releaseWorkflow: options.release,
     releasableCommits: ReleasableCommits.exec(releasableCommitsCmd.join(' --grep ')),
+
+    // This is the version we actually run GitHub workflows on
+    workflowNodeVersion: '18.12.0',
   };
 }
 
@@ -100,6 +104,9 @@ export function buildNodeProjectDefaultOptions(options: Cdk8sTeamNodeProjectOpti
   return {
     // if release is enabled, default to releasing to npm as well
     releaseToNpm: options.release,
+
+    // This is the minimum version that our consumers should have
+    // (moving this to 18.x requires moving off of TypeScript 4/jsii-compiler 1)
     minNodeVersion: '16.20.0',
     workflowNodeVersion: 'lts/*',
     depsUpgradeOptions,

--- a/src/projects/typescript.ts
+++ b/src/projects/typescript.ts
@@ -44,7 +44,6 @@ export interface Cdk8sTeamTypeScriptProjectOptions extends typescript.TypeScript
 export class Cdk8sTeamTypeScriptProject extends typescript.TypeScriptProject {
 
   constructor(options: Cdk8sTeamTypeScriptProjectOptions) {
-
     node.validateOptions(options);
     node.validateProjectName(options);
 


### PR DESCRIPTION
The newest jsii requires running on Node 18.12:

```
error jsii@5.3.7: The engine "node" is incompatible with this module. Expected version ">= 18.12.0". Got "16.20.2"
```

Upgrade all cdk8s workflows.
