### PR TITLE
chore: fix the projen peerDependency range

### DIFF
--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -117,6 +117,7 @@
     },
     {
       "name": "projen",
+      "version": ">=0.79.2 <1",
       "type": "peer"
     },
     {

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -3,7 +3,9 @@ import * as src from './src';
 const project = new src.Cdk8sTeamJsiiProject({
   name: '@cdk8s/projen-common',
   description: 'Common projen configuration shared between cdk8s-team org projects.',
-  peerDeps: ['projen'],
+
+  // Must use >=, <, because ^ does not have correct semantics for 0.* versions
+  peerDeps: ['projen@>=0.79.2 <1'],
   deps: ['codemaker'],
   bundledDeps: ['codemaker', 'deepmerge'],
   projenrcTs: true,

--- a/package.json
+++ b/package.json
@@ -53,14 +53,14 @@
     "jsii-docgen": "^7.2.9",
     "jsii-pacmak": "^1.94.0",
     "jsii-rosetta": "1.x",
-    "projen": "^0.79.2",
+    "projen": "0.79.2",
     "standard-version": "^9",
     "ts-jest": "^27",
     "ts-node": "^10.9.2",
     "typescript": "^4.9.5"
   },
   "peerDependencies": {
-    "projen": "^0.79.2"
+    "projen": ">=0.79.2 <1"
   },
   "dependencies": {
     "codemaker": "^1.94.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4133,7 +4133,7 @@ process-nextick-args@~2.0.0:
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"
   integrity sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==
 
-projen@^0.79.2:
+projen@0.79.2:
   version "0.79.2"
   resolved "https://registry.yarnpkg.com/projen/-/projen-0.79.2.tgz#ac1d51a07ad3fcb503ca712055b430042ccab853"
   integrity sha512-ZKO2GDsJyU+MfsQAcvpMKPrWcuS2rPPCpqf2biZ7rcBVdYnDiOn03G1Gm9G/wRereMdDTciL6DYqsxTF4UvfqA==


### PR DESCRIPTION
Must use `>=0.79 <1` syntax, instead of `^` syntax for `0.*` versions.
