### PR TITLE
fix: `projen-common` prevents `projen` upgrades

### DIFF
--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -4,7 +4,7 @@ const project = new src.Cdk8sTeamJsiiProject({
   name: '@cdk8s/projen-common',
   description: 'Common projen configuration shared between cdk8s-team org projects.',
 
-  // Must use >=, <, because ^ does not have correct semantics for 0.* versions
+  // Must use >=, <, because ^ does not have correct semantics for 0.x versions
   peerDeps: ['projen@>=0.79.2 <1'],
   deps: ['codemaker'],
   bundledDeps: ['codemaker', 'deepmerge'],

--- a/yarn.lock
+++ b/yarn.lock
@@ -1855,9 +1855,9 @@ dotgitignore@^2.1.0:
     minimatch "^3.0.4"
 
 electron-to-chromium@^1.4.601:
-  version "1.4.637"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.637.tgz#ed8775cf5e0c380c3e8452e9818a0e4b7a671ac4"
-  integrity sha512-G7j3UCOukFtxVO1vWrPQUoDk3kL70mtvjc/DC/k2o7lE0wAdq+Vwp1ipagOow+BH0uVztFysLWbkM/RTIrbK3w==
+  version "1.4.639"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.639.tgz#c6f9cc685f9efb2980d2cfc95a27f8142c9adf28"
+  integrity sha512-CkKf3ZUVZchr+zDpAlNLEEy2NJJ9T64ULWaDgy3THXXlPVPkLu3VOs9Bac44nebVtdwl2geSj6AxTtGDOxoXhg==
 
 emittery@^0.8.1:
   version "0.8.1"


### PR DESCRIPTION
Because of an incorrect peerDependency range, this package prevents projen from being updated to modern versions.

This is a re-roll of
https://github.com/cdk8s-team/cdk8s-projen-common/pull/704, but using a commit message that actually forces a release of a new version of this package.
