### PR TITLE
fix: bundled dependencies were not considered as runtime

### DIFF
--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -342,13 +342,13 @@
       },
       "steps": [
         {
-          "exec": "npx npm-check-updates@16 --upgrade --target=minor --peer --dep=prod,optional --filter=codemaker"
+          "exec": "npx npm-check-updates@16 --upgrade --target=minor --peer --dep=prod,optional --filter=codemaker,deepmerge"
         },
         {
           "exec": "yarn install --check-files"
         },
         {
-          "exec": "yarn upgrade codemaker"
+          "exec": "yarn upgrade codemaker deepmerge"
         },
         {
           "exec": "npx projen"

--- a/src/projects/node.ts
+++ b/src/projects/node.ts
@@ -95,7 +95,7 @@ export function buildNodeProjectDefaultOptions(options: Cdk8sTeamNodeProjectOpti
     // and by bumping peer dependencies we force the customer to also unnecessarily upgrade, which they may not want
     // to do. Never mind that peerDependencies are usually also devDependencies, so it doesn't make sense to upgrade
     // them without also upgrading devDependencies.
-    types: [DependencyType.RUNTIME, DependencyType.OPTIONAL],
+    types: [DependencyType.RUNTIME, DependencyType.OPTIONAL, DependencyType.BUNDLED],
     workflowOptions: {
       schedule: UpgradeDependenciesSchedule.expressions([UPGRADE_RUNTIME_DEPENDENCIES_SCHEDULE]),
     },

--- a/test/projects/jsii.test.ts
+++ b/test/projects/jsii.test.ts
@@ -1,5 +1,19 @@
-import { Testing } from 'projen';
+import { TaskRuntime, Testing } from 'projen';
 import * as src from '../../src';
+
+test('upgrade-runtime-dependencies includes bundled', () => {
+
+  const project = new src.Cdk8sTeamJsiiProject({
+    name: 'root',
+    defaultReleaseBranch: 'main',
+    bundledDeps: ['bundled1'],
+  });
+
+  const tasks = Testing.synth(project)[TaskRuntime.MANIFEST_FILE].tasks;
+
+  expect(tasks['upgrade-runtime-dependencies'].steps[2].exec).toStrictEqual('yarn upgrade bundled1');
+
+});
 
 test('deps upgrade options are merged', () => {
 

--- a/test/projects/node.test.ts
+++ b/test/projects/node.test.ts
@@ -1,4 +1,4 @@
-import { Testing } from 'projen';
+import { TaskRuntime, Testing } from 'projen';
 import * as src from '../../src';
 
 test('deps upgrade options are merged', () => {
@@ -153,3 +153,18 @@ test('can configure backport', () => {
 
   expect(Testing.synth(project)).toMatchSnapshot();
 });
+
+test('upgrade-runtime-dependencies includes bundled', () => {
+
+  const project = new src.Cdk8sTeamNodeProject({
+    name: 'root',
+    defaultReleaseBranch: 'main',
+    bundledDeps: ['bundled1'],
+  });
+
+  const tasks = Testing.synth(project)[TaskRuntime.MANIFEST_FILE].tasks;
+
+  expect(tasks['upgrade-runtime-dependencies'].steps[2].exec).toStrictEqual('yarn upgrade bundled1');
+
+});
+

--- a/test/projects/typescript.test.ts
+++ b/test/projects/typescript.test.ts
@@ -1,5 +1,20 @@
-import { Testing } from 'projen';
+import { TaskRuntime, Testing } from 'projen';
 import * as src from '../../src';
+
+test('upgrade-runtime-dependencies includes bundled', () => {
+
+  const project = new src.Cdk8sTeamTypeScriptProject({
+    name: 'root',
+    defaultReleaseBranch: 'main',
+    bundledDeps: ['bundled1'],
+  });
+
+  const tasks = Testing.synth(project)[TaskRuntime.MANIFEST_FILE].tasks;
+
+  expect(tasks['upgrade-runtime-dependencies'].steps[2].exec).toStrictEqual('yarn upgrade bundled1');
+
+});
+
 
 test('deps upgrade options are merged', () => {
 


### PR DESCRIPTION
I had previously thought that since bundled dependencies eventually end up as runtime dependencies in the `package.json`, it wasn't necessary to explicitly configure them. But the constructions of the dependencies list happens because projen puts those into runtime deps. 