### PR TITLE
fix: remove pinning of `backport`

### DIFF
--- a/src/components/backport/backport.ts
+++ b/src/components/backport/backport.ts
@@ -51,8 +51,7 @@ export class Backport extends Component {
       },
     });
 
-    // pinning because of https://github.com/sqren/backport/issues/451
-    project.addDevDeps('backport@8.5.0');
+    project.addDevDeps('backport');
 
     // backport task to branches based on pr labels (i.e not branch specific)
     const backportTask = this.createTask(project);

--- a/test/projects/__snapshots__/jsii.test.ts.snap
+++ b/test/projects/__snapshots__/jsii.test.ts.snap
@@ -4141,7 +4141,6 @@ tsconfig.tsbuildinfo
       Object {
         "name": "backport",
         "type": "build",
-        "version": "8.5.0",
       },
       Object {
         "name": "constructs",
@@ -4658,7 +4657,7 @@ UNEXPECTED BREAKING CHANGES: add keys such as 'removed:constructs.Node.of' to .c
         "name": "upgrade-dev-dependencies",
         "steps": Array [
           Object {
-            "exec": "npx npm-check-updates@16 --upgrade --target=minor --peer --dep=dev --filter=eslint-import-resolver-typescript,eslint-plugin-import,jsii-diff",
+            "exec": "npx npm-check-updates@16 --upgrade --target=minor --peer --dep=dev --filter=backport,eslint-import-resolver-typescript,eslint-plugin-import,jsii-diff",
           },
           Object {
             "exec": "yarn install --check-files",
@@ -4995,7 +4994,7 @@ echo \\"Configured core.hooksPath to \${hooksdir}\\"
       "@types/node": "16.18.78",
       "@typescript-eslint/eslint-plugin": "^6",
       "@typescript-eslint/parser": "^6",
-      "backport": "8.5.0",
+      "backport": "*",
       "constructs": "^10.0.0",
       "eslint": "^8",
       "eslint-import-resolver-typescript": "*",

--- a/test/projects/__snapshots__/node.test.ts.snap
+++ b/test/projects/__snapshots__/node.test.ts.snap
@@ -881,7 +881,6 @@ permissions-backup.acl
       Object {
         "name": "backport",
         "type": "build",
-        "version": "8.5.0",
       },
       Object {
         "name": "constructs",
@@ -1206,7 +1205,7 @@ permissions-backup.acl
         "name": "upgrade-dev-dependencies",
         "steps": Array [
           Object {
-            "exec": "npx npm-check-updates@16 --upgrade --target=minor --peer --dep=dev --filter=jest",
+            "exec": "npx npm-check-updates@16 --upgrade --target=minor --peer --dep=dev --filter=backport,jest",
           },
           Object {
             "exec": "yarn install --check-files",
@@ -1529,7 +1528,7 @@ echo \\"Configured core.hooksPath to \${hooksdir}\\"
       "organization": false,
     },
     "devDependencies": Object {
-      "backport": "8.5.0",
+      "backport": "*",
       "constructs": "^10.0.0",
       "jest": "*",
       "jest-junit": "^15",

--- a/test/projects/__snapshots__/typescript.test.ts.snap
+++ b/test/projects/__snapshots__/typescript.test.ts.snap
@@ -3314,7 +3314,6 @@ tsconfig.tsbuildinfo
       Object {
         "name": "backport",
         "type": "build",
-        "version": "8.5.0",
       },
       Object {
         "name": "constructs",
@@ -3706,7 +3705,7 @@ tsconfig.tsbuildinfo
         "name": "upgrade-dev-dependencies",
         "steps": Array [
           Object {
-            "exec": "npx npm-check-updates@16 --upgrade --target=minor --peer --dep=dev --filter=@types/jest,eslint-import-resolver-typescript,eslint-plugin-import,jest,ts-jest",
+            "exec": "npx npm-check-updates@16 --upgrade --target=minor --peer --dep=dev --filter=@types/jest,backport,eslint-import-resolver-typescript,eslint-plugin-import,jest,ts-jest",
           },
           Object {
             "exec": "yarn install --check-files",
@@ -4042,7 +4041,7 @@ echo \\"Configured core.hooksPath to \${hooksdir}\\"
       "@types/node": "16.18.78",
       "@typescript-eslint/eslint-plugin": "^6",
       "@typescript-eslint/parser": "^6",
-      "backport": "8.5.0",
+      "backport": "*",
       "constructs": "^10.0.0",
       "eslint": "^8",
       "eslint-import-resolver-typescript": "*",


### PR DESCRIPTION
We were pinning because of [this issue](https://github.com/sqren/backport/issues/451), but it is now very old and a new major version has been released so its probably resolved. 

I also tested locally that it works fine with the new major version. 