### PR TITLE
feat: issues are tracked only in the `cdk8s` repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
 # @cdk8s/projen-common
 
 Common configuration for projen-managed projects in the cdk8s-team GitHub org.
+


### PR DESCRIPTION
This was implemented in https://github.com/cdk8s-team/cdk8s-projen-common/pull/961 but mistakenly marked as a `chore` so it wasn't released. Dummy commit to roll it out.